### PR TITLE
Creating resolution dialog and minor style enhancements 

### DIFF
--- a/components/MuiTheme.ts
+++ b/components/MuiTheme.ts
@@ -9,9 +9,9 @@ export const MuiTheme = createMuiTheme({
     primary: {
       light: "#90caf9",
       main: "#90caf9",
-      dark: "#90caf9",
+      dark: "#323e96",
     },
-    // #64b5f6
+
     secondary: {
       light: "#000000",
       main: "#000000",

--- a/components/templates/Sidebar.tsx
+++ b/components/templates/Sidebar.tsx
@@ -12,13 +12,13 @@ export const SideBarMainItems = (
         </ListItemIcon>
         <ListItemText primary="Projects" />
       </ListItem>
-      <ListItem button disabled>
-        <ListItemIcon>
-          <BarChartIcon />
-        </ListItemIcon>
-        <ListItemText primary="Charts" />
-      </ListItem>
     </Link>
+    <ListItem button disabled>
+      <ListItemIcon>
+        <BarChartIcon />
+      </ListItemIcon>
+      <ListItemText primary="Charts" />
+    </ListItem>
   </div>
 )
 

--- a/components/templates/Sidebar.tsx
+++ b/components/templates/Sidebar.tsx
@@ -1,11 +1,7 @@
 import React from "react"
-import ListItem from "@material-ui/core/ListItem"
-import ListItemIcon from "@material-ui/core/ListItemIcon"
-import ListItemText from "@material-ui/core/ListItemText"
-import ListSubheader from "@material-ui/core/ListSubheader"
+import { ListItem, ListItemText, ListItemIcon, Link } from "@material-ui/core/"
 import DashboardIcon from "@material-ui/icons/Dashboard"
 import BarChartIcon from "@material-ui/icons/Assignment" // AssignmentIcon, LayersIcon, BarChartIcon
-import Link from "@material-ui/core/Link"
 
 export const SideBarMainItems = (
   <div>
@@ -16,18 +12,25 @@ export const SideBarMainItems = (
         </ListItemIcon>
         <ListItemText primary="Projects" />
       </ListItem>
+      <ListItem button disabled>
+        <ListItemIcon>
+          <BarChartIcon />
+        </ListItemIcon>
+        <ListItemText primary="Charts" />
+      </ListItem>
     </Link>
   </div>
 )
 
 export const SideBarSecondaryItems = (
   <div>
-    <ListSubheader inset>Charts</ListSubheader>
+    {/* for the later use */}
+    {/* <ListSubheader inset>Title</ListSubheader>
     <ListItem button disabled>
       <ListItemIcon>
         <BarChartIcon />
       </ListItemIcon>
-      <ListItemText primary="Coming Soon" />
-    </ListItem>
+      <ListItemText primary="Text" />
+    </ListItem> */}
   </div>
 )

--- a/components/templates/TestsBlock.tsx
+++ b/components/templates/TestsBlock.tsx
@@ -29,6 +29,11 @@ const useStyles = makeStyles(theme => ({
     width: "100%",
     maxWidth: 3500,
   },
+  testLine: {
+    width: "100%",
+    maxWidth: 3500,
+    maxHeight: 50,
+  },
   counter: {
     margin: 10,
   },
@@ -51,13 +56,20 @@ const useStyles = makeStyles(theme => ({
     flexDirection: "column",
   },
   bigMargin: {
-    marginTop: theme.spacing(3),
-  },
-  smallMargin: {
     marginTop: theme.spacing(1),
+    marginButtom: theme.spacing(3),
   },
-  tab: {
-    width: "50%",
+  paperNoPadding: {
+    display: "flex",
+    overflow: "auto",
+    flexDirection: "column",
+  },
+  tabs: {
+    marginTop: theme.spacing(1),
+    width: "30%",
+  },
+  backgroundColor: {
+    maxWidth: "50",
   },
 }))
 
@@ -76,8 +88,8 @@ function TabPanel(props: TabPanelProps) {
       component="div"
       role="tabpanel"
       hidden={value !== index}
-      id={`full-width-tabpanel-${index}`}
-      aria-labelledby={`full-width-tab-${index}`}
+      id={`tabpanel-${index}`}
+      aria-labelledby={`tab-${index}`}
       {...other}
     >
       {value === index && <Box p={3}>{children}</Box>}
@@ -87,8 +99,8 @@ function TabPanel(props: TabPanelProps) {
 
 function a11yProps(index: any) {
   return {
-    id: `full-width-tab-${index}`,
-    "aria-controls": `full-width-tabpanel-${index}`,
+    id: `tab-${index}`,
+    "aria-controls": `tabpanel-${index}`,
   }
 }
 
@@ -99,48 +111,6 @@ type Props = {
 export const TestsBlock = function(props: Props) {
   const { children } = props
   const classes = useStyles(props)
-
-  const ErrorExpansionPanel = withStyles({
-    root: {
-      backgroundColor: "#ffa9a9",
-      borderBottom: "1px solid #ec7d7d",
-      boxShadow: "none",
-      "&:not(:last-child)": {
-        borderBottom: 0,
-      },
-      "&:before": {
-        display: "none",
-      },
-      "&$expanded": {
-        margin: "auto",
-      },
-    },
-    expanded: {},
-  })(MuiExpansionPanel)
-
-  const ErrorExpansionPanelSummary = withStyles({
-    root: {
-      backgroundColor: "#f0a9a9",
-      borderBottom: "1px solid #ec7d7d",
-      marginBottom: -1,
-      minHeight: 56,
-      "&$expanded": {
-        minHeight: 56,
-      },
-    },
-    content: {
-      "&$expanded": {
-        margin: "12px 0",
-      },
-    },
-    expanded: {},
-  })(MuiExpansionPanelSummary)
-
-  const ErrorExpansionPanelDetails = withStyles(theme => ({
-    root: {
-      padding: theme.spacing(2),
-    },
-  }))(MuiExpansionPanelDetails)
 
   const [expandedSuite, setExpandedSuite] = React.useState<string | false>(
     false
@@ -160,67 +130,118 @@ export const TestsBlock = function(props: Props) {
     setExpandedTest(isExpanded ? testPanel : false)
   }
 
-  const [expandedTestMessage, setExpandedTestMessage] = React.useState<
+  const [expandedErrorMessage, setExpandedErrorMessage] = React.useState<
     string | false
   >(false)
-  const expandCollapseTestMessage = (testMessagePanel: string) => (
+  const expandCollapseErrorMessage = (errorMessagePanel: string) => (
     _event: React.ChangeEvent<{}>,
     isExpanded: boolean
   ) => {
-    setExpandedTestMessage(isExpanded ? testMessagePanel : false)
+    setExpandedErrorMessage(isExpanded ? errorMessagePanel : false)
   }
+
+  const ErrorMessagePanel = withStyles({
+    root: {
+      backgroundColor: "#f9dbdb", // error message expanded color
+      borderBottom: "1px solid #ffa7a7",
+      boxShadow: "none",
+      "&:not(:last-child)": {
+        borderBottom: 0,
+      },
+      "&:before": {
+        display: "none",
+      },
+      "&$expanded": {
+        margin: "auto",
+      },
+    },
+    expanded: {},
+  })(MuiExpansionPanel)
+
+  const ErrorMessageCollapsedLineSummary = withStyles({
+    root: {
+      backgroundColor: "#f9e6e6", // error message color
+      borderBottom: "1px solid #f9e6e6",
+      marginBottom: -1,
+      minHeight: 56,
+      "&$expanded": {
+        minHeight: 56,
+      },
+    },
+    content: {
+      "&$expanded": {
+        margin: "12px 0",
+      },
+    },
+    expanded: {},
+  })(MuiExpansionPanelSummary)
+
+  const ErrorMessagePanelDetails = withStyles(theme => ({
+    root: {
+      padding: theme.spacing(2),
+    },
+  }))(MuiExpansionPanelDetails)
 
   const testsTab = test => (
     <div key={test.id} className={classes.root}>
+      <Typography className={classes.bigMargin}>
+        Full path:
+        <span style={{ color: "grey" }}> {test.name.split(":")[0]}.</span>
+        <span style={{ color: "grey", fontWeight: "bold" }}>
+          {test.name.split(":")[1]}
+        </span>
+      </Typography>
       {test.message ? ( // if there is any error message - show the info, else - test passed
-        <Paper className={classes.paper} elevation={0}>
-          <div className={classes.root}>
-            <AppBar position="static" color="default">
-              <Tabs
-                value={historyTabValue}
-                onChange={handleTabChange}
-                indicatorColor="primary"
-                textColor="secondary"
-                variant="fullWidth"
-                aria-label="full width tabs example"
+        <Paper className={classes.paperNoPadding} elevation={0}>
+          <AppBar
+            style={{ backgroundColor: "white", border: "none" }}
+            variant="outlined"
+            position="relative"
+            className={classes.tabs}
+          >
+            <Tabs
+              value={historyTabValue}
+              onChange={handleTabChange}
+              indicatorColor="primary"
+              textColor="secondary"
+              variant="fullWidth"
+              aria-label="full width tabs example"
+            >
+              <Tab label="Error" {...a11yProps(0)} />
+              <Tab label="Test History" {...a11yProps(1)} />
+            </Tabs>
+          </AppBar>
+          <TabPanel value={historyTabValue} index={0}>
+            <ErrorMessagePanel
+              key={test.id}
+              expanded={expandedErrorMessage === test.message}
+              onChange={expandCollapseErrorMessage(test.message)}
+              TransitionProps={{ unmountOnExit: true }}
+            >
+              <ErrorMessageCollapsedLineSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel3bh-content"
               >
-                <Tab label="Overview" {...a11yProps(0)} />
-                <Tab label="History" {...a11yProps(1)} />
-              </Tabs>
-            </AppBar>
-            <TabPanel value={historyTabValue} index={0}>
-              <Typography className={classes.bigMargin}>Error: </Typography>{" "}
-              <ErrorExpansionPanel
-                key={test.id}
-                expanded={expandedTestMessage === test.message}
-                onChange={expandCollapseTestMessage(test.message)}
-              >
-                <ErrorExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography color="textPrimary">{test.message}</Typography>
-                </ErrorExpansionPanelSummary>
-                <ErrorExpansionPanelDetails>
-                  <List>
-                    <ListItem button>
-                      {" "}
-                      {test.error_type}
-                      {test.trace}
-                      {test.retries}
-                    </ListItem>
-                  </List>
-                </ErrorExpansionPanelDetails>
-              </ErrorExpansionPanel>
-              <Typography className={classes.bigMargin}>File Name: </Typography>{" "}
-              <Typography component="h2" color="textSecondary">
-                {test.file}
-              </Typography>
-            </TabPanel>
-            <TabPanel value={historyTabValue} index={1}>
-              TODO: Historical info for this test
-            </TabPanel>
-          </div>
+                <Typography color="textPrimary">{test.message}</Typography>
+              </ErrorMessageCollapsedLineSummary>
+              <ErrorMessagePanelDetails>
+                <List>
+                  <ListItem button>
+                    {" "}
+                    {test.error_type}
+                    {test.trace}
+                    {test.retries}
+                  </ListItem>
+                </List>
+              </ErrorMessagePanelDetails>
+            </ErrorMessagePanel>
+          </TabPanel>
+          <TabPanel value={historyTabValue} index={1}>
+            TODO: Historical info for this test
+          </TabPanel>
         </Paper>
       ) : (
-        <Typography>This test passed</Typography>
+        <div></div>
       )}
     </div>
   )
@@ -288,8 +309,12 @@ export const TestsBlock = function(props: Props) {
               key={suite.id}
               expanded={expandedSuite === suite.name}
               onChange={expandCollapseSuite(suite.name)}
+              TransitionProps={{ unmountOnExit: true }}
             >
-              <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+              <ExpansionPanelSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel1bh-content"
+              >
                 {setStatusColor(suite.test_suite_status)}
                 <Typography className={classes.suiteStatus} color="textPrimary">
                   {suite.name}
@@ -297,34 +322,35 @@ export const TestsBlock = function(props: Props) {
               </ExpansionPanelSummary>
               <ExpansionPanelDetails>
                 {/* Expanded tests list for each suite */}
-                <List key={suite.id} className={classes.root}>
+                <List key={suite.id} className={classes.root} dense>
                   {suite.tests.map(test => (
-                    <div key={test.id}>
-                      <ListItem className={classes.root} button>
-                        <ExpansionPanel
-                          className={classes.root}
-                          key={test.id}
-                          expanded={expandedTest === test.name}
-                          onChange={expandCollapseTest(test.name)}
+                    <ListItem key={test.id} className={classes.root}>
+                      <ExpansionPanel
+                        className={classes.root}
+                        key={test.id}
+                        expanded={expandedTest === test.name}
+                        onChange={expandCollapseTest(test.name)}
+                        TransitionProps={{ unmountOnExit: true }}
+                      >
+                        <ExpansionPanelSummary
+                          expandIcon={<ExpandMoreIcon />}
+                          aria-controls="panel2bh-content"
                         >
-                          <ExpansionPanelSummary
-                            expandIcon={<ExpandMoreIcon />}
+                          {setStatusColor(test.status)}
+                          <Typography
+                            className={classes.suiteStatus}
+                            color="textPrimary"
                           >
-                            {setStatusColor(test.status)}
-                            <Typography
-                              className={classes.suiteStatus}
-                              color="textPrimary"
-                            >
-                              {test.name}{" "}
-                            </Typography>{" "}
-                          </ExpansionPanelSummary>
-                          <ExpansionPanelDetails>
-                            {testsTab(test)}
-                          </ExpansionPanelDetails>
-                        </ExpansionPanel>
-                      </ListItem>
-                    </div>
-                  ))}{" "}
+                            {/* getting the name of the test */}
+                            {test.name.split(":")[1]}
+                          </Typography>
+                        </ExpansionPanelSummary>
+                        <ExpansionPanelDetails>
+                          {testsTab(test)}
+                        </ExpansionPanelDetails>
+                      </ExpansionPanel>
+                    </ListItem>
+                  ))}
                 </List>
               </ExpansionPanelDetails>
             </ExpansionPanel>

--- a/components/templates/TestsBlock.tsx
+++ b/components/templates/TestsBlock.tsx
@@ -16,6 +16,8 @@ import {
   Tab,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
+import CheckIcon from "@material-ui/icons/Check"
+import CloseIcon from "@material-ui/icons/Close"
 import TripOriginIcon from "@material-ui/icons/TripOrigin"
 import UseAnimations from "react-useanimations"
 import MuiExpansionPanel from "@material-ui/core/ExpansionPanel"
@@ -53,6 +55,9 @@ const useStyles = makeStyles(theme => ({
   },
   smallMargin: {
     marginTop: theme.spacing(1),
+  },
+  tab: {
+    width: "50%",
   },
 }))
 
@@ -97,7 +102,8 @@ export const TestsBlock = function(props: Props) {
 
   const ErrorExpansionPanel = withStyles({
     root: {
-      border: "1px solid rgba(0, 0, 0, .125)",
+      backgroundColor: "#ffa9a9",
+      borderBottom: "1px solid #ec7d7d",
       boxShadow: "none",
       "&:not(:last-child)": {
         borderBottom: 0,
@@ -114,8 +120,8 @@ export const TestsBlock = function(props: Props) {
 
   const ErrorExpansionPanelSummary = withStyles({
     root: {
-      backgroundColor: "rgba(0, 0, 0, .03)",
-      borderBottom: "1px solid rgba(0, 0, 0, .125)",
+      backgroundColor: "#f0a9a9",
+      borderBottom: "1px solid #ec7d7d",
       marginBottom: -1,
       minHeight: 56,
       "&$expanded": {
@@ -221,23 +227,23 @@ export const TestsBlock = function(props: Props) {
 
   function setStatusColor(status) {
     let statusIcon
-    if (/.*(\w*ass\w*)\b/.test(status)) {
+    if (status === "Passed" || status === "Successful") {
       statusIcon = (
-        <TripOriginIcon
+        <CheckIcon
           style={{
             color: "green",
           }}
-        ></TripOriginIcon>
+        ></CheckIcon>
       )
-    } else if (/.*(\w*ail\w*)\b/.test(status)) {
+    } else if (status === "Failed") {
       statusIcon = (
-        <TripOriginIcon
+        <CloseIcon
           style={{
             color: "red",
           }}
-        ></TripOriginIcon>
+        ></CloseIcon>
       )
-    } else if (/.*(\w*kip\w*)\b/.test(status)) {
+    } else if (status === "Skipped" || status === "Incomplete") {
       statusIcon = (
         <TripOriginIcon
           style={{
@@ -245,7 +251,7 @@ export const TestsBlock = function(props: Props) {
           }}
         ></TripOriginIcon>
       )
-    } else if (/.*(\w*run\w*)\b/.test(status)) {
+    } else if (status === "Running") {
       statusIcon = (
         <UseAnimations
           animationKey="loading"

--- a/components/templates/TestsBlock.tsx
+++ b/components/templates/TestsBlock.tsx
@@ -14,6 +14,10 @@ import {
   AppBar,
   Tabs,
   Tab,
+  Dialog,
+  DialogTitle,
+  ListItemText,
+  Button,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import CheckIcon from "@material-ui/icons/Check"
@@ -57,6 +61,9 @@ const useStyles = makeStyles(theme => ({
   },
   bigMargin: {
     marginTop: theme.spacing(1),
+    marginButtom: theme.spacing(3),
+  },
+  marginBottom: {
     marginButtom: theme.spacing(3),
   },
   paperNoPadding: {
@@ -182,6 +189,67 @@ export const TestsBlock = function(props: Props) {
     },
   }))(MuiExpansionPanelDetails)
 
+  interface ResolutionProps {
+    open: boolean
+    selectedValue: string
+    onClose: (value: string) => void
+  }
+
+  const testResolutions = [
+    "Not set",
+    "Test is flaky",
+    "Product defect",
+    "Test needs to be updated",
+    "To investigate",
+  ]
+
+  const [openResolutionDialog, setOpenResolutionDialog] = React.useState(false)
+  const [selectedResolutionValue, setSelectedResolutionValue] = React.useState(
+    testResolutions[0]
+  )
+
+  const handleResolutionDialogOpen = () => {
+    setOpenResolutionDialog(true)
+  }
+
+  const handleResolutionDialogClose = (value: string) => {
+    setOpenResolutionDialog(false)
+    setSelectedResolutionValue(value)
+  }
+
+  function SetTestResolution(props: ResolutionProps) {
+    const { onClose, selectedValue, open } = props
+
+    const handleClose = () => {
+      onClose(selectedValue)
+    }
+
+    const handleListItemClick = (value: string) => {
+      onClose(value)
+    }
+
+    return (
+      <Dialog
+        onClose={handleClose}
+        aria-labelledby="simple-dialog-title"
+        open={open}
+      >
+        <DialogTitle id="simple-dialog-title">Set resolution:</DialogTitle>
+        <List>
+          {testResolutions.map(resolution => (
+            <ListItem
+              button
+              onClick={() => handleListItemClick(resolution)}
+              key={resolution}
+            >
+              <ListItemText primary={resolution} />
+            </ListItem>
+          ))}
+        </List>
+      </Dialog>
+    )
+  }
+
   const testsTab = test => (
     <div key={test.id} className={classes.root}>
       <Typography className={classes.bigMargin}>
@@ -235,6 +303,37 @@ export const TestsBlock = function(props: Props) {
                 </List>
               </ErrorMessagePanelDetails>
             </ErrorMessagePanel>
+            <div>
+              <Typography className={classes.bigMargin}>
+                <Button
+                  disabled
+                  variant="outlined"
+                  color="primary"
+                  onClick={handleResolutionDialogOpen}
+                  className={classes.bigMargin}
+                >
+                  Set test resolution
+                </Button>{" "}
+                {/* <span style={{ marginLeft: "15px" }}>Selected: </span>
+                <span style={{ color: "grey", fontStyle: "italic" }}>
+                  {selectedResolutionValue}
+                </span> */}
+                <span
+                  style={{
+                    color: "grey",
+                    fontStyle: "italic",
+                    marginLeft: "15px",
+                  }}
+                >
+                  Coming Soon
+                </span>
+              </Typography>
+              <SetTestResolution
+                open={openResolutionDialog}
+                selectedValue={selectedResolutionValue}
+                onClose={handleResolutionDialogClose}
+              />
+            </div>
           </TabPanel>
           <TabPanel value={historyTabValue} index={1}>
             TODO: Historical info for this test

--- a/constants/Page.ts
+++ b/constants/Page.ts
@@ -15,7 +15,7 @@ export class Page implements IEnum<Page> {
   public static readonly PROJECTS = new Page(
     2,
     "Projects",
-    "Select a project to view last launches and test runs",
+    "Select a project to view latest test runs",
     "/"
   )
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,11 +34,14 @@ const useStyles = makeStyles(theme => ({
     height: 240,
     width: 300,
   },
-  context: {
+  projectStatus: {
     flex: 1,
+    paddingTop: theme.spacing(1),
+    textAlign: "center",
   },
-  title: {
-    paddingTop: theme.spacing(2),
+  projectTitle: {
+    paddingTop: theme.spacing(7),
+    textAlign: "center",
   },
 }))
 export interface TestProject {
@@ -133,18 +136,17 @@ function Index(props: Props) {
                       <Typography
                         component="p"
                         variant="h4"
-                        className={classes.title}
+                        className={classes.projectTitle}
                       >
                         {project.name}
                       </Typography>
                       <Typography
                         color="textSecondary"
-                        className={classes.context}
+                        className={classes.projectStatus}
                         component="p"
                       >
                         {project.project_status}
                       </Typography>
-                      <Typography color="primary"> View details</Typography>
                     </Paper>{" "}
                   </ListItem>
                 </List>

--- a/pages/launches/[launchesByProjectId].tsx
+++ b/pages/launches/[launchesByProjectId].tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
 
 function setStatusColor(status) {
   let statusIcon
-  if (/.*(\w*ass\w*)\b/.test(status)) {
+  if (status === "Successful") {
     statusIcon = (
       <TripOriginIcon
         style={{
@@ -42,7 +42,7 @@ function setStatusColor(status) {
         }}
       ></TripOriginIcon>
     )
-  } else if (/.*(\w*ail\w*)\b/.test(status)) {
+  } else if (status === "Failed") {
     statusIcon = (
       <TripOriginIcon
         style={{
@@ -50,15 +50,7 @@ function setStatusColor(status) {
         }}
       ></TripOriginIcon>
     )
-  } else if (/.*(\w*kip\w*)\b/.test(status)) {
-    statusIcon = (
-      <TripOriginIcon
-        style={{
-          color: "grey",
-        }}
-      ></TripOriginIcon>
-    )
-  } else if (/.*(\w*ess\w*)\b/.test(status)) {
+  } else if (status === "In Process") {
     statusIcon = (
       <UseAnimations
         animationKey="loading"
@@ -91,9 +83,6 @@ function Launches(props: Props) {
     <BasePage className={classes.root}>
       <title>Δ | Launches</title>
       <Breadcrumbs aria-label="breadcrumb">
-        <Link color="inherit" href="/">
-          Delta Reporter
-        </Link>
         <Link color="inherit" href={`/`}>
           Projects
         </Link>
@@ -115,20 +104,19 @@ function Launches(props: Props) {
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Name</TableCell>
-                      <TableCell>Status</TableCell>
+                      <TableCell></TableCell>
+                      <TableCell></TableCell>
                       <TableCell></TableCell>
                     </TableRow>
                   </TableHead>
                   <TableBody>
                     {props.launches.map(launch => (
                       <TableRow key={launch.id} hover>
-                        <TableCell>{launch.name}</TableCell>
                         <TableCell>
                           {" "}
                           {setStatusColor(launch.launch_status)}
                         </TableCell>
-
+                        <TableCell>{launch.name}</TableCell>
                         <TableCell>
                           {" "}
                           <Link

--- a/pages/testruns/[runsByLaunchId].tsx
+++ b/pages/testruns/[runsByLaunchId].tsx
@@ -16,7 +16,8 @@ import {
   Breadcrumbs,
 } from "@material-ui/core"
 import UseAnimations from "react-useanimations"
-import TripOriginIcon from "@material-ui/icons/TripOrigin"
+import CheckIcon from "@material-ui/icons/Check"
+import CloseIcon from "@material-ui/icons/Close"
 
 const useStyles = makeStyles(theme => ({
   root: {},
@@ -34,31 +35,23 @@ const useStyles = makeStyles(theme => ({
 
 function setStatusColor(status) {
   let statusIcon
-  if (/.*(\w*ass\w*)\b/.test(status)) {
+  if (status === "Passed") {
     statusIcon = (
-      <TripOriginIcon
+      <CheckIcon
         style={{
           color: "green",
         }}
-      ></TripOriginIcon>
+      ></CheckIcon>
     )
-  } else if (/.*(\w*ail\w*)\b/.test(status)) {
+  } else if (status === "Failed") {
     statusIcon = (
-      <TripOriginIcon
+      <CloseIcon
         style={{
           color: "red",
         }}
-      ></TripOriginIcon>
+      ></CloseIcon>
     )
-  } else if (/.*(\w*kip\w*)\b/.test(status)) {
-    statusIcon = (
-      <TripOriginIcon
-        style={{
-          color: "grey",
-        }}
-      ></TripOriginIcon>
-    )
-  } else if (/.*(\w*ess\w*)\b/.test(status)) {
+  } else if (status === "Running") {
     statusIcon = (
       <UseAnimations
         animationKey="loading"
@@ -87,7 +80,7 @@ function setTestTypeBadge(testType) {
     badge = <img alt={testType} src="/unit.png" width="40" height="30" />
   } else if (/.*(\w*ntegration\w*)\b/.test(testType)) {
     badge = <img alt={testType} src="/api.png" width="40" height="30" />
-  } else if (/.*(\w*end\w*)\b/.test(testType)) {
+  } else if (/.*(\w*nd\w*)\b/.test(testType)) {
     badge = <img alt={testType} src="/ui.png" width="40" height="30" />
   } else {
     badge = (
@@ -113,9 +106,6 @@ function Testruns(props: Props) {
     <BasePage className={classes.root}>
       <title>Δ | Test Runs</title>
       <Breadcrumbs aria-label="breadcrumb">
-        <Link color="inherit" href="/">
-          Delta Reporter
-        </Link>
         <Link color="inherit" href={`/`}>
           Projects
         </Link>
@@ -140,15 +130,21 @@ function Testruns(props: Props) {
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Duration</TableCell>
-                      <TableCell>Test Type</TableCell>
-                      <TableCell>Status</TableCell>
+                      <TableCell></TableCell>
+                      <TableCell></TableCell>
+                      <TableCell></TableCell>
                       <TableCell></TableCell>
                     </TableRow>
                   </TableHead>
                   <TableBody>
                     {props.test_runs.map(testRun => (
                       <TableRow key={testRun.id} hover>
+                        <TableCell>
+                          {setStatusColor(testRun.test_run_status)}
+                        </TableCell>
+                        <TableCell>
+                          {setTestTypeBadge(testRun.test_type)}
+                        </TableCell>
                         {testRun.duration.minutes === 0 ? (
                           <TableCell>{testRun.duration.seconds} sec</TableCell>
                         ) : (
@@ -157,12 +153,6 @@ function Testruns(props: Props) {
                             {testRun.duration.seconds} sec
                           </TableCell>
                         )}
-                        <TableCell>
-                          {setTestTypeBadge(testRun.test_type)}
-                        </TableCell>
-                        <TableCell>
-                          {setStatusColor(testRun.test_run_status)}
-                        </TableCell>
                         <TableCell>
                           {" "}
                           <Link underline="none" href={`/tests/${testRun.id}`}>

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles(theme => ({
 
 type Props = {
   test_history: Test[]
-  test_history_failed: Test[]
 }
 
 function Tests(props: Props) {
@@ -44,9 +43,6 @@ function Tests(props: Props) {
     <BasePage className={classes.root}>
       <title>Δ | Tests</title>
       <Breadcrumbs aria-label="breadcrumb">
-        <Link color="inherit" href="/">
-          Delta Reporter
-        </Link>
         <Link color="inherit" href={`/`}>
           Projects
         </Link>
@@ -98,17 +94,8 @@ Tests.getInitialProps = async (context): Promise<Props> => {
   )
   const tests = await testsByTestRunIdReq.json()
 
-  const failedTestsOnlyByTestRunIdReq = await fetch(
-    `${process.env.deltaCore}/api/v1/tests_history/test_status/1/test_run/${testsByRunId}`,
-    {
-      method: "GET",
-    }
-  )
-  const failedTestsOnly = await failedTestsOnlyByTestRunIdReq.json()
-
   return {
     test_history: tests,
-    test_history_failed: failedTestsOnly,
   }
 }
 


### PR DESCRIPTION
1. Styling project container a lil bit

2. Test tab (_having issues here, can't decide how to style it so it doesn't look too dense_):
- creating a test resolution dialog (disabled for the moment)
- making error box red
- changing icons for test status to be green V and red X

<img width="1172" alt="Screenshot 2020-04-21 at 21 56 42" src="https://user-images.githubusercontent.com/44492659/79913184-1fc1cf00-841b-11ea-8c67-257fbf2756fb.png">
