### PR TITLE
Adding test type buttons for the launch, test stats for the suite

### DIFF
--- a/components/templates/SuitesAndTestsList.tsx
+++ b/components/templates/SuitesAndTestsList.tsx
@@ -10,6 +10,7 @@ import {
   List,
   ListItem,
   ExpansionPanelDetails,
+  Tooltip,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import CheckIcon from "@material-ui/icons/Check"
@@ -110,6 +111,85 @@ export const SuitesAndTestsList = function(props: Props) {
     return statusIcon
   }
 
+  function showStats(passed, failed, incomplete, skipped) {
+    return (
+      <div style={{ paddingLeft: "70%" }}>
+        {passed !== 0 ? (
+          <Tooltip title="Passed">
+            <span
+              style={{
+                borderStyle: "ridge",
+                borderColor: "green",
+                color: "green",
+                padding: "3px",
+                margin: "3px",
+                fontWeight: "bold",
+              }}
+            >
+              {passed}
+            </span>
+          </Tooltip>
+        ) : (
+          <span></span>
+        )} 
+        {failed !== 0 ? ( 
+          <Tooltip title="Failed">
+            <span
+              style={{
+                borderStyle: "ridge",
+                borderColor: "red",
+                color: "red",
+                padding: "3px",
+                margin: "3px",
+                fontWeight: "bold",
+              }}
+            >
+              {failed}
+            </span>
+        </Tooltip>
+        ) : (
+          <span></span>
+        )}
+        {incomplete !== 0 ? (
+          <Tooltip title="Incomplete">
+            <span
+              style={{
+                borderStyle: "ridge",
+                borderColor: "orange",
+                color: "orange",
+                padding: "3px",
+                margin: "3px",
+                fontWeight: "bold",
+              }}
+            >
+              {incomplete}
+            </span>
+          </Tooltip>
+        ) : (
+          <span></span>
+        )}
+        {skipped !== 0 ? (
+          <Tooltip title="Skipped">
+            <span
+              style={{
+                borderStyle: "ridge",
+                borderColor: "grey",
+                color: "grey",
+                padding: "3px",
+                margin: "3px",
+                fontWeight: "bold",
+              }}
+            >
+              {skipped}
+            </span>
+          </Tooltip>
+        ) : (
+          <span></span>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div>
       {children.map(testRun => (
@@ -129,12 +209,25 @@ export const SuitesAndTestsList = function(props: Props) {
                 <Typography className={classes.suiteStatus} color="textPrimary">
                   {suite.name}
                 </Typography>
+                {showStats(
+                  suite.tests_passed,
+                  suite.tests_failed,
+                  suite.tests_incomplete,
+                  suite.tests_skipped
+                )}
               </ExpansionPanelSummary>
               <ExpansionPanelDetails>
                 {/* Expanded tests list for each suite */}
-                <List key={suite.test_suite_history_id} className={classes.root} dense>
+                <List
+                  key={suite.test_suite_history_id}
+                  className={classes.root}
+                  dense
+                >
                   {suite.tests.map(test => (
-                    <ListItem key={test.test_history_id} className={classes.root}>
+                    <ListItem
+                      key={test.test_history_id}
+                      className={classes.root}
+                    >
                       <ExpansionPanel
                         className={classes.root}
                         key={test.test_history_id}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,6 +56,18 @@ export interface TestLaunch {
   launch_status: string
   project: string
   data: { url?: string }
+  test_run_stats: [
+    {
+      test_run_id: number
+      test_type: string
+      tests_total: number
+      tests_failed: number
+      tests_passed: number
+      tests_running: number
+      tests_incomplete: number
+      tests_skipped: number
+    }
+  ]
 }
 export interface TestRun {
   test_run_id: number
@@ -93,6 +105,12 @@ export interface SuiteAndTest {
         seconds: number
         years: number
       }
+      tests_total: number
+      tests_failed: number
+      tests_passed: number
+      tests_running: number
+      tests_incomplete: number
+      tests_skipped: number
       tests: [
         {
           duration: {

--- a/pages/launches/[launchesByProjectId].tsx
+++ b/pages/launches/[launchesByProjectId].tsx
@@ -155,6 +155,7 @@ function Launches(props: Props) {
                                   paddingRight: "3px",
                                   paddingBottom: "0px",
                                   paddingTop: "0px",
+                                  marginLeft: "5px",
                                 }}
                               >
                                 {testRun.test_type}{" "}

--- a/pages/launches/[launchesByProjectId].tsx
+++ b/pages/launches/[launchesByProjectId].tsx
@@ -145,23 +145,26 @@ function Launches(props: Props) {
                           </TableCell>
                           <TableCell>{launch.name}</TableCell>
                           <TableCell>
-                            {" "}
                             {launch.test_run_stats.map(testRun => (
-                              <div>
-                                <Button
-                                  variant="contained"
-                                  href={`/tests/${testRun.test_run_id}`}
-                                >
-                                  {testRun.test_type}{" "}
-                                  {testRun.tests_total ===
-                                  testRun.tests_passed +
-                                    testRun.tests_skipped ? (
-                                    <div> {setStatusColor("Successful")} </div>
-                                  ) : (
-                                    <div>{setStatusColor("Failed")} </div>
-                                  )}{" "}
-                                </Button>
-                              </div>
+                              <Button
+                                variant="contained"
+                                href={`/tests/${testRun.test_run_id}`}
+                                style={{
+                                  fontSize: "12px",
+                                  paddingLeft: "8px",
+                                  paddingRight: "3px",
+                                  paddingBottom: "0px",
+                                  paddingTop: "0px",
+                                }}
+                              >
+                                {testRun.test_type}{" "}
+                                {testRun.tests_total ===
+                                testRun.tests_passed + testRun.tests_skipped ? (
+                                  <div> {setStatusColor("Successful")} </div>
+                                ) : (
+                                  <div>{setStatusColor("Failed")} </div>
+                                )}{" "}
+                              </Button>
                             ))}
                           </TableCell>
                         </TableRow>

--- a/pages/launches/[launchesByProjectId].tsx
+++ b/pages/launches/[launchesByProjectId].tsx
@@ -16,8 +16,10 @@ import {
   Typography,
   Link,
   Breadcrumbs,
+  Button,
 } from "@material-ui/core"
-import TripOriginIcon from "@material-ui/icons/TripOrigin"
+import CheckIcon from "@material-ui/icons/Check"
+import CloseIcon from "@material-ui/icons/Close"
 import UseAnimations from "react-useanimations"
 
 const useStyles = makeStyles(theme => ({
@@ -38,19 +40,19 @@ function setStatusColor(status) {
   let statusIcon
   if (status === "Successful") {
     statusIcon = (
-      <TripOriginIcon
+      <CheckIcon
         style={{
           color: "green",
         }}
-      ></TripOriginIcon>
+      ></CheckIcon>
     )
   } else if (status === "Failed") {
     statusIcon = (
-      <TripOriginIcon
+      <CloseIcon
         style={{
           color: "red",
         }}
-      ></TripOriginIcon>
+      ></CloseIcon>
     )
   } else if (status === "In Process") {
     statusIcon = (
@@ -144,13 +146,23 @@ function Launches(props: Props) {
                           <TableCell>{launch.name}</TableCell>
                           <TableCell>
                             {" "}
-                            <Link
-                              underline="none"
-                              href={`/testruns/${launch.launch_id}`}
-                            >
-                              {" "}
-                              View{" "}
-                            </Link>{" "}
+                            {launch.test_run_stats.map(testRun => (
+                              <div>
+                                <Button
+                                  variant="contained"
+                                  href={`/tests/${testRun.test_run_id}`}
+                                >
+                                  {testRun.test_type}{" "}
+                                  {testRun.tests_total ===
+                                  testRun.tests_passed +
+                                    testRun.tests_skipped ? (
+                                    <div> {setStatusColor("Successful")} </div>
+                                  ) : (
+                                    <div>{setStatusColor("Failed")} </div>
+                                  )}{" "}
+                                </Button>
+                              </div>
+                            ))}
                           </TableCell>
                         </TableRow>
                       ))}

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -30,6 +30,10 @@ const useStyles = makeStyles(theme => ({
     overflow: "auto",
     flexDirection: "column",
   },
+  padding: {
+    paddingBottom: theme.spacing(1),
+    paddingLeft: "80%",
+  },
 }))
 
 type Props = {
@@ -79,6 +83,13 @@ function Tests(props: Props) {
                     </Link>{" "}
                     run
                   </Typography>
+                  <Link
+                    underline="always"
+                    className={classes.padding}
+                    href={`/failedTests/${props.test_history[0].test_run_id}`}
+                  >
+                    Show only Failed Tests
+                  </Link>
                   <SuitesAndTestsList>{props.test_history}</SuitesAndTestsList>
                 </Paper>
               </Grid>


### PR DESCRIPTION
Test version to see if it's usable/makes sense.

Buttons  on the launch to go directly to the test suite: <img width="1046" alt="Screenshot 2020-05-22 at 23 21 01" src="https://user-images.githubusercontent.com/44492659/82715607-d2d84f00-9c8b-11ea-9cd8-48f26b3c494b.png">

Number of failed/passed tests on the suite level: <img width="1270" alt="Screenshot 2020-05-23 at 00 17 08" src="https://user-images.githubusercontent.com/44492659/82715609-d4097c00-9c8b-11ea-802c-57b54bd804e0.png">
