### PR TITLE
New style for tests - splitting page in half

### DIFF
--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -98,7 +98,7 @@ type Props = {
 export const BasePage = function(props: Props) {
   const { children, className } = props
   const classes = useStyles(props)
-  const [open, setOpen] = React.useState(true)
+  const [open, setOpen] = React.useState(false)
 
   const handleDrawerOpen = () => {
     setOpen(true)

--- a/components/templates/BasePage.tsx
+++ b/components/templates/BasePage.tsx
@@ -98,13 +98,13 @@ type Props = {
 export const BasePage = function(props: Props) {
   const { children, className } = props
   const classes = useStyles(props)
-  const [open, setOpen] = React.useState(false)
+  const [openSideBar, setOpenSideBar] = React.useState(false)
 
   const handleDrawerOpen = () => {
-    setOpen(true)
+    setOpenSideBar(true)
   }
   const handleDrawerClose = () => {
-    setOpen(false)
+    setOpenSideBar(false)
   }
 
   return (
@@ -112,7 +112,7 @@ export const BasePage = function(props: Props) {
       <CssBaseline />
       <AppBar
         position="absolute"
-        className={clsx(classes.appBar, open && classes.appBarShift)}
+        className={clsx(classes.appBar, openSideBar && classes.appBarShift)}
       >
         <Toolbar className={classes.toolbar}>
           <IconButton
@@ -122,7 +122,7 @@ export const BasePage = function(props: Props) {
             onClick={handleDrawerOpen}
             className={clsx(
               classes.menuButton,
-              open && classes.menuButtonHidden
+              openSideBar && classes.menuButtonHidden
             )}
           >
             <MenuIcon />
@@ -152,9 +152,9 @@ export const BasePage = function(props: Props) {
       <Drawer
         variant="permanent"
         classes={{
-          paper: clsx(classes.drawerPaper, !open && classes.drawerPaperClose),
+          paper: clsx(classes.drawerPaper, !openSideBar && classes.drawerPaperClose),
         }}
-        open={open}
+        open={openSideBar}
       >
         <div className={classes.toolbarIcon}>
           <IconButton onClick={handleDrawerClose}>

--- a/components/templates/TestExpanded.tsx
+++ b/components/templates/TestExpanded.tsx
@@ -228,7 +228,7 @@ export const TestExpanded = function(props: TestProps) {
 
   return (
     <div key={children.test_history_id} className={classes.root} style={{paddingLeft:"50px"}}>
-       {children.name ? ( // if there is any error message - show the info, else - test passed
+       {children.name ? ( // when page is just loaded and no test selected - half page to be blank
        <div> 
       <Typography style={{paddingTop:"50px"}}>
         Full path:
@@ -261,7 +261,6 @@ export const TestExpanded = function(props: TestProps) {
               expanded={expandedErrorMessage === children.message}
               onChange={expandCollapseErrorMessage(children.message)}
               TransitionProps={{ unmountOnExit: true }}
-              style={{ width: "100%" }}
             >
               <ErrorMessageCollapsedLineSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography

--- a/components/templates/TestExpanded.tsx
+++ b/components/templates/TestExpanded.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles(theme => ({
   },
   tabs: {
     marginTop: theme.spacing(1),
-    width: "40%",
+    width: "100%",
   },
   backgroundColor: {
     maxWidth: "50",
@@ -227,10 +227,10 @@ export const TestExpanded = function(props: TestProps) {
   }
 
   return (
-    <div key={children.test_history_id} className={classes.root}>
+    <div key={children.test_history_id} className={classes.root} style={{paddingLeft:"50px"}}>
        {children.name ? ( // if there is any error message - show the info, else - test passed
        <div> 
-      <Typography className={classes.bigMargin}>
+      <Typography style={{paddingTop:"50px"}}>
         Full path:
         <span style={{ color: "grey" }}> {children.name}</span>
       </Typography>
@@ -261,6 +261,7 @@ export const TestExpanded = function(props: TestProps) {
               expanded={expandedErrorMessage === children.message}
               onChange={expandCollapseErrorMessage(children.message)}
               TransitionProps={{ unmountOnExit: true }}
+              style={{ width: "100%" }}
             >
               <ErrorMessageCollapsedLineSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography
@@ -348,7 +349,7 @@ export const TestExpanded = function(props: TestProps) {
       )}
      </div>
        ) : (
-        <div>Please select a test</div>
+      <Paper></Paper>
       )}
     </div>
   )

--- a/components/templates/TestExpanded.tsx
+++ b/components/templates/TestExpanded.tsx
@@ -224,6 +224,8 @@ export const TestExpanded = function(props: TestProps) {
 
   return (
     <div key={children.test_history_id} className={classes.root}>
+       {children.name ? ( // if there is any error message - show the info, else - test passed
+       <div> 
       <Typography className={classes.bigMargin}>
         Full path:
         <span style={{ color: "grey" }}> {children.name}</span>
@@ -306,6 +308,10 @@ export const TestExpanded = function(props: TestProps) {
         </Paper>
       ) : (
         <div></div>
+      )}
+     </div>
+       ) : (
+        <div>Please select a test</div>
       )}
     </div>
   )

--- a/components/templates/showTestStats.js
+++ b/components/templates/showTestStats.js
@@ -7,7 +7,7 @@ export function showTestStats(passed, failed, incomplete, skipped) {
         {passed !== 0 ? (
           <Tooltip title="Tests Passed"> 
             <Chip size="small" variant="outlined" style={{
-                backgroundColor: "#c6e1d4",  marginLeft:"3px", 
+                backgroundColor: "#c6e1d4",  marginLeft:"3px" 
               }} label={passed} />
           </Tooltip>
         ) : (

--- a/components/templates/showTestStats.js
+++ b/components/templates/showTestStats.js
@@ -6,8 +6,8 @@ export function showTestStats(passed, failed, incomplete, skipped) {
       <div style={{ position: "absolute", right: "120px" }}>
         {passed !== 0 ? (
           <Tooltip title="Tests Passed"> 
-            <Chip style={{
-                backgroundColor: "#c6e1d4",  marginLeft:"3px"
+            <Chip size="small" variant="outlined" style={{
+                backgroundColor: "#c6e1d4",  marginLeft:"3px", 
               }} label={passed} />
           </Tooltip>
         ) : (
@@ -15,7 +15,7 @@ export function showTestStats(passed, failed, incomplete, skipped) {
         )}
         {failed !== 0 ? (
           <Tooltip title="Tests Failed">
-            <Chip style={{
+            <Chip size="small" variant="outlined" style={{
                 backgroundColor: "#e1c6c6",  marginLeft:"3px"
               }} label={failed} />
           </Tooltip>
@@ -24,7 +24,7 @@ export function showTestStats(passed, failed, incomplete, skipped) {
         )}
         {incomplete !== 0 ? (
           <Tooltip title="Tests Incomplete">
-            <Chip style={{
+            <Chip size="small" variant="outlined" style={{
                 backgroundColor: "#e1d4c6", marginLeft:"3px"
               }} label={incomplete} />
           </Tooltip>
@@ -33,7 +33,7 @@ export function showTestStats(passed, failed, incomplete, skipped) {
         )}
         {skipped !== 0 ? (
           <Tooltip title="Tests Skipped">
-            <Chip 
+            <Chip size="small" variant="outlined"
             style={{ marginLeft:"3px" }}
             label={skipped} />
           </Tooltip>

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -15,7 +15,6 @@ import {
   ExpansionPanelDetails,
   List,
   ListItem,
-  Divider,
   Button,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -15,6 +15,8 @@ import {
   ExpansionPanelDetails,
   List,
   ListItem,
+  Divider,
+  Button,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 
@@ -28,6 +30,7 @@ const useStyles = makeStyles(theme => ({
   },
   container: {
     paddingTop: theme.spacing(4),
+    maxWidth: 3400,
     paddingBottom: theme.spacing(4),
   },
   paper: {
@@ -37,8 +40,9 @@ const useStyles = makeStyles(theme => ({
     flexDirection: "column",
   },
   padding: {
-    paddingBottom: theme.spacing(1),
-    paddingLeft: "80%",
+    marginBottom: "5px",
+    marginLeft: "80%",
+    color: "#353690",
   },
   suiteStatus: {
     paddingLeft: theme.spacing(4),
@@ -47,27 +51,6 @@ const useStyles = makeStyles(theme => ({
 
 type Props = {
   test_history: SuiteAndTest[]
-}
-
-function SplitPanel() {
-  const [rightSide, setRightSide] = useState([]);
-
-  function changeRightSide(value) {
-    setRightSide(value);
-  }
-
-  return (
-    <div> 
-    <div style={{float:"left", width:"75%"}}>
-      <button  onClick={() => changeRightSide(1)}>1</button>
-      <button onClick={() => changeRightSide(2)}>2</button>
-      ttr;a;aa
-    </div>
-    <div style={{float:"left", width:"25%"}}>
-    <p>{rightSide}</p>
-  </div>
-  </div>
-  );
 }
 
 function Tests(props: Props) {
@@ -93,7 +76,7 @@ function Tests(props: Props) {
       <title>Δ | Tests</title>
        {props.test_history[0] ? ( // checking if props exist (if there are tests for this run)
         <div> 
-          <Breadcrumbs aria-label="breadcrumb">
+          <Breadcrumbs>
             <Link color="inherit" href={`/`}>
               Projects
             </Link>
@@ -125,17 +108,11 @@ function Tests(props: Props) {
                       </Link>{" "}
                       run
                     </Typography>
-                    <Link
-                      underline="always"
-                      className={classes.padding}
-                      variant="subtitle1"
-                      href={`/failedTests/${props.test_history[0].test_run_id}`}
-                      style={{ color: "#353690" }}
-                    >
+                    <Button variant="text" className={classes.padding} href={`/failedTests/${props.test_history[0].test_run_id}`}>
                       Show only Failed Tests
-                    </Link>
+                    </Button>
                     <div>
-                    <div style={{float:"left", width:"50%", overflow:"hidden"}}>
+                    <div style={{float:"left", width:"50%", overflow:"hidden", height: "max-content", paddingRight:"20px"}}>
 
                       {props.test_history.map(testRun => (
                        <div key={testRun.test_run_id}>
@@ -197,7 +174,7 @@ function Tests(props: Props) {
                         </div>
                       ))}
                     </div>
-                    <div style={{float:"left", width:"50%", overflow:"hidden"}}>
+                    <div style={{float:"left", width:"45%", overflow:"hidden"}}>
                       <TestExpanded>{rightSide}</TestExpanded>
                     </div>
                     </div>
@@ -223,7 +200,7 @@ Tests.getInitialProps = async (context): Promise<Props> => {
 
   // Suites and tests (inside suites)
   const testsByTestRunIdReq = await fetch(
-    `https://delta-core.dsch.dev/api/v1/tests_history/test_run/${testsByRunId}`,
+    `${process.env.deltaCore}/api/v1/tests_history/test_run/${testsByRunId}`,
     {
       method: "GET",
     }


### PR DESCRIPTION
- making sidebar closed by default, so we have more space on the page
- bringing back all the code that was once nicely moved in the separate components (🙈 , will refactor it later, I promise)
- splitting the page in two, so the list of tests is on one side and test info on the other
- we will  think of a better design of tests info section (right side), for now keeping it as it was
<img width="1600" alt="Screenshot 2020-06-18 at 15 36 39" src="https://user-images.githubusercontent.com/44492659/85042897-ac6edc00-b183-11ea-94d9-edf17277a122.png">

