### PR TITLE
Resolution v1.1

### DIFF
--- a/components/templates/ListOfSuites.tsx
+++ b/components/templates/ListOfSuites.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@material-ui/core/styles"
 import {
   showStatusIcon,
   showTestStats,
+  showResolutionText,
   TestExpanded,
 } from "../../components/templates"
 import {
@@ -182,7 +183,12 @@ export const ListOfSuites = function(props: Props) {
                           <Typography  className={darkMode ? classes.nameOfTestOrSuiteDark : classes.nameOfTestOrSuiteLight}>
                             {test.name}
                           </Typography>
-                          {/* </> */}
+                          {/* if resolution for the current run exists - show it, otherwise - show the general resolution for this test */}
+                          {test.test_history_resolution ? (
+                            showResolutionText(test.test_history_resolution, darkMode)
+                          ) : (
+                            showResolutionText(test.test_resolution, darkMode)
+                          )}
                         </ListItem>
                       </a>
                     ))}

--- a/components/templates/Test.tsx
+++ b/components/templates/Test.tsx
@@ -81,6 +81,16 @@ export const TestExpanded = function(props: TestProps) {
     return (microseconds / 1000).toString()[0]
   }
 
+  function getBackgroundColorForTheTab(darkMode) {
+    if(darkMode) return "#2a2a2a"
+    else return "white"
+  }
+
+  function getTextColorForTheTab(darkMode) {
+    if(darkMode) return "#8c8d8d"
+    else return "black"
+  }
+
   return (
     <div
       key={children.test_history_id}
@@ -105,9 +115,9 @@ export const TestExpanded = function(props: TestProps) {
           </Typography>
           <Tabs style={{ marginTop: "20px" }} className={darkMode ? classes.textColorDarkMode : classes.textColorLightMode}>
             <TabList>
-              <Tab style={{ fontSize: "16px" }}>Info</Tab>
-              <Tab style={{ fontSize: "16px" }}>Resolution</Tab>
-              <Tab style={{ fontSize: "16px" }}>Test History</Tab>
+              <Tab style={{ fontSize: "16px", backgroundColor: getBackgroundColorForTheTab(darkMode), color: getTextColorForTheTab(darkMode) }} >Info</Tab>
+              <Tab style={{ fontSize: "16px", backgroundColor: getBackgroundColorForTheTab(darkMode), color: getTextColorForTheTab(darkMode)  }}>Resolution</Tab>
+              <Tab style={{ fontSize: "16px", backgroundColor: getBackgroundColorForTheTab(darkMode), color: getTextColorForTheTab(darkMode)  }}>Test History</Tab>
             </TabList>
             {/* info tab */}
             <TabPanel>
@@ -209,7 +219,7 @@ export const TestExpanded = function(props: TestProps) {
             </TabPanel>
             <TabPanel>
               {/* historical info tab */}
-              <HistoricalTests>{children}</HistoricalTests>
+              <HistoricalTests darkMode={darkMode}>{children}</HistoricalTests>
             </TabPanel>
           </Tabs>
         </Paper>

--- a/components/templates/Test.tsx
+++ b/components/templates/Test.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react"
+import React from "react"
 import { makeStyles } from "@material-ui/core/styles"
-import { Paper, Typography, Button } from "@material-ui/core"
+import { Paper, Typography } from "@material-ui/core"
 import {
   TestErrorMessageAccordion,
   TestMediaAccordion,
@@ -46,15 +46,6 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
-const testResolutions = [
-  "Not set",
-  "Test is flaky",
-  "Product defect",
-  "Test needs to be updated",
-  "To investigate",
-  "Environment issue",
-]
-
 interface TestProps {
   children: any
   darkMode: boolean
@@ -63,19 +54,6 @@ interface TestProps {
 export const TestExpanded = function(props: TestProps) {
   const { children, darkMode } = props
   const classes = useStyles(props)
-
-  const [openResolutionDialog, setOpenResolutionDialog] = useState(false)
-  const [resolutionResponse, setResolutionResponse] = useState(
-    testResolutions[0]
-  )
-  const handleResolutionDialogOpen = () => {
-    setOpenResolutionDialog(true)
-  }
-
-  const handleResolutionDialogClose = (value: string) => {
-    setOpenResolutionDialog(false)
-    setResolutionResponse(value)
-  }
 
   function convertToSeconds(microseconds: number) {
     return (microseconds / 1000).toString()[0]
@@ -179,42 +157,7 @@ export const TestExpanded = function(props: TestProps) {
             <TabPanel>
               {/* set resolution tab */}
               <div style={{ paddingTop: "20px" }}>
-                {children.resolution === "Not set" ? ( // when resolution is not set - show button
-                  <Typography className={classes.bigMargin}>
-                    <Button
-                      variant="outlined"
-                      color="primary"
-                      onClick={handleResolutionDialogOpen}
-                      className={classes.bigMargin}
-                    >
-                      Set test resolution
-                    </Button>{" "}
-                    <span
-                      style={{
-                        color: "grey",
-                        fontStyle: "italic",
-                      }}
-                    >
-                      {resolutionResponse}
-                    </span>
-                  </Typography>
-                ) : (
-                  <Typography style={{ paddingTop: "10px" }}>
-                    Test Resolution:
-                    <span style={{ color: "grey" }}>
-                      {" "}
-                      {children.resolution}{" "}
-                    </span>
-                  </Typography>
-                )}
-
-                <TestResolution
-                  open={openResolutionDialog}
-                  selectedValue={resolutionResponse}
-                  onClose={handleResolutionDialogClose}
-                  testHistoryId={children.test_history_id}
-                  testResolutions={testResolutions}
-                />
+                  <TestResolution resolution = {children.test_history_resolution} testId={children.test_id} testHistoryId={children.test_history_id}></TestResolution>
               </div>
             </TabPanel>
             <TabPanel>

--- a/components/templates/TestHistory.tsx
+++ b/components/templates/TestHistory.tsx
@@ -21,10 +21,21 @@ const fetcher = url => fetch(url).then(res => res.json())
 
 interface TestProps {
   children: any
+  darkMode: boolean
 }
 
 export const HistoricalTests = function(props: TestProps) {
-  const { children } = props
+  const { children, darkMode } = props
+
+  function getBackgroundColor(darkMode) {
+    if(darkMode) return "#2a2a2a"
+    else return "white"
+  }
+
+  function getTextColor(darkMode) {
+    if(darkMode) return "#8c8d8d"
+    else return "black"
+  }
 
   const { data, error } = useSWR(
     `${process.env.publicDeltaCore}/api/v1/test_history/test_id/${children.test_id}`,
@@ -72,12 +83,13 @@ export const HistoricalTests = function(props: TestProps) {
                 expanded={historicalTestsExpandedPanel === test.test_history_id}
                 onChange={expandCollapsePanel(test.test_history_id)}
                 TransitionProps={{ unmountOnExit: true }}
+                style={{backgroundColor: getBackgroundColor(darkMode), color: getTextColor(darkMode)}}
               >
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography color="textPrimary">
-                    {showStatusText(test.status)}{" "}
-                    {showDateText(test.end_datetime)}
-                    {showResolutionText(test.resolution)}{" "}
+                  <Typography>
+                    {showStatusText(test.status, darkMode)}{" "}
+                    {showDateText(test.end_datetime, darkMode)}
+                    {showResolutionText(test.resolution, darkMode)}{" "}
                     {test.test_history_id === children.test_history_id ? ( // if it's current test - show the badge 
                       <Tooltip title="Current test">
                         <button

--- a/components/templates/TestResolution.tsx
+++ b/components/templates/TestResolution.tsx
@@ -1,35 +1,40 @@
-import React from "react"
+import React, { useState } from "react"
 import {
-  List,
-  ListItem,
-  Dialog,
-  DialogTitle,
-  ListItemText,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
 } from "@material-ui/core"
+import { getResolutionName } from "./showResolution";
 
-interface ResolutionProps {
-  open: boolean
-  selectedValue: string
-  onClose: (value: string) => void
-  testHistoryId: string | number
-  testResolutions: string[]
+interface TestProps {
+  testHistoryId: any
+  testId: any
+  resolution: any
 }
 
-export const TestResolution = function(props: ResolutionProps) {
-  const { onClose, selectedValue, open, testHistoryId, testResolutions } = props
+export const TestResolution = function(props: TestProps) {
+    const { testHistoryId, testId, resolution } = props
+    const [resolutionName, setResolutionName] = useState(resolution)
+  
+    const handleDropdownSelect = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setResolutionName(event.target.value as string);
+    changeResolution(getResolutionName(event.target.value))
+      if (typeof window !== 'undefined') {
+      window.location.reload(false) //temporarily refreshing the page when resolution is updated, need to come up with a better solution
+      }
+    };
 
-  const handleClose = () => {
-    onClose(selectedValue)
-  }
-
-  const handleListItemClick = async (resolution: string) => {
+  const changeResolution = async (resolutionValue) => {
     // PUT request using fetch with async/await
     const requestOptions = {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         test_history_id: testHistoryId,
-        test_resolution: resolution,
+        test_resolution: resolutionValue,
+        test_id: testId
       }),
     }
     console.log(requestOptions)
@@ -38,28 +43,31 @@ export const TestResolution = function(props: ResolutionProps) {
       `${process.env.publicDeltaCore}/api/v1/test_history_resolution`,
       requestOptions
     )
-    const data = await response.json()
-    onClose(data.message)
+    await response.json()
   }
 
   return (
-    <Dialog
-      onClose={handleClose}
-      aria-labelledby="simple-dialog-title"
-      open={open}
-    >
-      <DialogTitle id="simple-dialog-title">Set resolution:</DialogTitle>
-      <List>
-        {testResolutions.map(resolution => (
-          <ListItem
-            button
-            onClick={() => handleListItemClick(resolution)}
-            key={resolution}
-          >
-            <ListItemText primary={resolution} />
-          </ListItem>
-        ))}
-      </List>
-    </Dialog>
+    <div>
+      <Typography style={{fontStyle:"italic"}}>
+      Set or update the resolution for this test: 
+      </Typography>
+      <FormControl variant="outlined" style={{minWidth: 250, marginTop: "30px"}}>
+        <InputLabel>Resolution</InputLabel>
+        <Select
+          value={resolutionName}
+          onChange={handleDropdownSelect}
+          label="Resolution"
+        >
+            <MenuItem value={null}></MenuItem>
+            <MenuItem value={1}>Not set</MenuItem>
+            <MenuItem value={2}>Test is flaky</MenuItem>
+            <MenuItem value={3}>Product defect</MenuItem>
+            <MenuItem value={4}>Test needs to be updated</MenuItem>
+            <MenuItem value={5}>To investigate</MenuItem>
+            <MenuItem value={6}>Environment issue</MenuItem>
+        </Select>
+      </FormControl> 
+    
+  </div>
   )
 }

--- a/components/templates/showDate.js
+++ b/components/templates/showDate.js
@@ -1,25 +1,39 @@
 import React from "react"
 import {Typography, Tooltip} from "@material-ui/core"
 
-export function showDateText(date) {
+export function showDateText(date, darkMode) {
     let dateBadge
     let dateString = new Date(date).toUTCString();
     let day = dateString.split(' ').slice(0, 3).join(' ');
     let hour = dateString.split(' ').slice(-2)[0];
     dateString= day + ", " + hour
-
-    dateBadge = (
-        <Tooltip title="End date">
-            <button style={
-                {
-                    color: "#6B8E23",
-                    margin: "5px",
-                    backgroundColor: "white",
-                    border: "none",
-                }
-            }>
-                {dateString} </button>
-        </Tooltip>
-    )
+    if(darkMode) {
+        dateBadge = (
+            <Tooltip title="End date">
+                <button style={
+                    {
+                        color: "#6B8E23",
+                        margin: "5px",
+                        backgroundColor: "#2a2a2a",
+                        border: "1px solid",
+                    }
+                }>
+                    {dateString} </button>
+            </Tooltip>
+        )
+    } else
+        dateBadge = (
+            <Tooltip title="End date">
+                <button style={
+                    {
+                        color: "#6B8E23",
+                        margin: "5px",
+                        backgroundColor: "white",
+                        border: "none",
+                    }
+                }>
+                    {dateString} </button>
+            </Tooltip>
+        )
     return dateBadge
 }

--- a/components/templates/showResolution.js
+++ b/components/templates/showResolution.js
@@ -1,84 +1,38 @@
 import React from "react"
 import {Typography, Tooltip} from "@material-ui/core"
 
-export function showResolutionText(resolution) {
+export function showResolutionText(resolution, darkMode) {
     let resolutionBadge
     if (resolution === "Not set") {
         resolutionBadge = ""
-    } else if (resolution === "Test is flaky") {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <button style={
-                    {
-                        color: "#FF8C00",
-                        margin: "5px",
-                        border: "1px #FF8C00 solid",
-                        backgroundColor: "white"
-                    }
-                }>Test is flaky</button>
-            </Tooltip>
-        )
-    } else if (resolution === "Product defect") {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <button style={
-                    {
-                        color: "#800000",
-                        margin: "5px",
-                        border: "1px #800000 solid",
-                        backgroundColor: "white"
-                    }
-                }>Product defect</button>
-            </Tooltip>
-        )
-    } else if (resolution === "Test needs to be updated") {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <button style={
-                    {
-                        color: "#66CDAA",
-                        margin: "5px",
-                        border: "1px #66CDAA solid",
-                        backgroundColor: "white"
-                    }
-                }>Test needs to be updated</button>
-            </Tooltip>
-        )
-    } else if (resolution === "To investigate") {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <button style={
-                    {
-                        color: "#00FF7F",
-                        margin: "5px",
-                        border: "1px #00FF7F solid",
-                        backgroundColor: "white"
-                    }
-                }>To investigate</button>
-            </Tooltip>
-        )
-    } else if (resolution === "Environment issue") {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <button style={
-                    {
-                        color: "#EE82EE",
-                        margin: "5px",
-                        border: "1px #EE82EE solid",
-                        backgroundColor: "white"
-                    }
-                }>Environment issue</button>
-            </Tooltip>
-        )
     } else {
-        resolutionBadge = (
-            <Tooltip title="Resolution">
-                <Typography style={
-                    {color: "grey"}
-                }>
-                    {resolution} </Typography>
-            </Tooltip>
+        if(darkMode) {
+            resolutionBadge = (
+                <Tooltip title="Resolution">
+                    <button style={
+                        {
+                            color: "#dda057",
+                            margin: "5px",
+                            border: "1px #dda057 solid",
+                            backgroundColor: "#2a2a2a"
+                        }
+                    }>Test is flaky</button>
+                </Tooltip>
+            )
+        }
+        else 
+            resolutionBadge = (
+                <Tooltip title="Resolution">
+                    <button style={
+                        {
+                            color: "#dda057",
+                            margin: "5px",
+                            border: "1px #dda057 solid",
+                            backgroundColor: "white"
+                        }
+                    }>Test is flaky</button>
+                </Tooltip>
         )
-    }
     return resolutionBadge
+    }
 }

--- a/components/templates/showResolution.js
+++ b/components/templates/showResolution.js
@@ -2,10 +2,19 @@ import React from "react"
 import {Typography, Tooltip} from "@material-ui/core"
 
 export function showResolutionText(resolution, darkMode) {
+
+    if(resolution == 1) resolution =  "Not set"
+    else if(resolution == 2) resolution =  "Test is flaky"
+    else if(resolution == 3) resolution =  "Product defect"
+    else if(resolution == 4) resolution =  "Test needs to be updated"
+    else if(resolution == 5) resolution =  "To investigate"
+    else if(resolution == 6) resolution =  "Environment issue"
+
     let resolutionBadge
-    if (resolution === "Not set") {
+    if (resolution === "Not set" || resolution === null) {
         resolutionBadge = ""
     } else {
+       
         if(darkMode) {
             resolutionBadge = (
                 <Tooltip title="Resolution">
@@ -16,7 +25,7 @@ export function showResolutionText(resolution, darkMode) {
                             border: "1px #dda057 solid",
                             backgroundColor: "#2a2a2a"
                         }
-                    }>Test is flaky</button>
+                    }>{resolution}</button>
                 </Tooltip>
             )
         }
@@ -30,9 +39,21 @@ export function showResolutionText(resolution, darkMode) {
                             border: "1px #dda057 solid",
                             backgroundColor: "white"
                         }
-                    }>Test is flaky</button>
+                    }>{resolution}</button>
                 </Tooltip>
         )
     return resolutionBadge
     }
+}
+
+export function getResolutionName(resolution) {
+    let resolutionName
+    if(resolution == 1) resolutionName =  "Not set"
+    else if(resolution == 2) resolutionName =  "Test is flaky"
+    else if(resolution == 3) resolutionName =  "Product defect"
+    else if(resolution == 4) resolutionName =  "Test needs to be updated"
+    else if(resolution == 5) resolutionName =  "To investigate"
+    else if(resolution == 6) resolutionName =  "Environment issue"
+    else return ""
+    return resolutionName
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -175,7 +175,8 @@ export interface SuiteAndTest {
           test_history_id: number
           test_id: number
           name: string
-          resolution: string
+          test_history_resolution: string
+          test_resolution: string
           message: string
           status: string
           error_type: string


### PR DESCRIPTION
- so now there will be a dropdown for test resolution 
- a badge is showing either current run resolution (if any) or general resolution for the test
- to remove the badge for the test - set the resolution to `Not Set`
- refreshing the page on each resolution setting for now (temp measure, while investigating how to update  the badge dynamically). It's bad UI, but just so that we can start using the functionality while I am trying to fix it.
<img width="1284" alt="Screenshot 2020-08-18 at 22 07 29" src="https://user-images.githubusercontent.com/44492659/90565714-44e30600-e19f-11ea-8c4f-f94f128201bd.png">
