### PR TITLE
Small UI improvements

### DIFF
--- a/components/templates/ListOfTests.tsx
+++ b/components/templates/ListOfTests.tsx
@@ -148,11 +148,13 @@ return(
           <Typography  className={darkMode ? classes.nameOfTestOrSuiteDark : classes.nameOfTestOrSuiteLight}>
             {test.name}
           </Typography>
-          {/* if resolution for the current run exists - show it, otherwise - show the general resolution for this test */}
+          {/* if resolution for the current run exists - show it, otherwise - show the historical resolution inherited from previous results */}
           {test.test_history_resolution != 1? (
-            showResolutionText(test.test_history_resolution, darkMode)
+            <>
+            {showResolutionText(test.test_history_resolution, darkMode, false)}
+            </>
           ) : (
-            showResolutionText(test.test_resolution, darkMode)
+            showResolutionText(test.test_resolution, darkMode, true)
           )}
       </ListItem>
     </a>

--- a/components/templates/ListOfTests.tsx
+++ b/components/templates/ListOfTests.tsx
@@ -138,7 +138,7 @@ return(
         className={setTextLineStyle(test.test_id === highlightedTest, darkMode)}
         >
           {showStatusIcon(test.status)}
-          {test.is_flaky (
+          {test.is_flaky ? (
             <Tooltip title="Flaky test. Failed more than 5 out of 10 times.">
               <WarningIcon style={{color: "red", width:"30px"}}></WarningIcon>  
             </Tooltip>

--- a/components/templates/ListOfTests.tsx
+++ b/components/templates/ListOfTests.tsx
@@ -138,7 +138,7 @@ return(
         className={setTextLineStyle(test.test_id === highlightedTest, darkMode)}
         >
           {showStatusIcon(test.status)}
-          {test.is_flaky=="true" ? (
+          {test.is_flaky (
             <Tooltip title="Flaky test. Failed more than 5 out of 10 times.">
               <WarningIcon style={{color: "red", width:"30px"}}></WarningIcon>  
             </Tooltip>

--- a/components/templates/Test.tsx
+++ b/components/templates/Test.tsx
@@ -89,7 +89,7 @@ export const TestExpanded = function(props: TestProps) {
             }}
             className={darkMode ? classes.textColorDarkMode : classes.textColorLightMode}
           >
-            {children.is_flaky=="true" ? (
+            {children.is_flaky ? (
               <Tooltip title="Flaky test. Failed more than 5 out of 10 times.">
                 <WarningIcon style={{color: "red", marginBottom:"-7px", width:"30px"}}></WarningIcon>  
               </Tooltip>

--- a/components/templates/TestExpandablePanels.tsx
+++ b/components/templates/TestExpandablePanels.tsx
@@ -157,16 +157,19 @@ export const TestMediaAccordion = function(props: TestProps) {
               <PanelDetails>
                 <CardActionArea>
                   {media.type === "img" ? (
-                    <CardMedia
-                      component="img"
-                      alt={media.filename}
-                      style={{ height: 360, maxWidth: 640 }}
-                      src={
-                        `${process.env.publicDeltaCore}/api/v1/get_file/` +
-                        media.file_id
-                      }
-                      title={media.filename}
-                    />
+                    <a href={`${process.env.publicDeltaCore}/api/v1/get_file/` +
+                    media.file_id} target="_blank">
+                      <CardMedia
+                        component="img"
+                        alt={media.filename}
+                        style={{ height: 360, maxWidth: 640 }}
+                        src={
+                          `${process.env.publicDeltaCore}/api/v1/get_file/` +
+                          media.file_id
+                        }
+                        title={media.filename}
+                      />
+                    </a>
                   ) : (
                     <ReactPlayer
                       url={`${process.env.publicDeltaCore}/api/v1/get_file/${media.file_id}`}

--- a/components/templates/TestHistory.tsx
+++ b/components/templates/TestHistory.tsx
@@ -89,7 +89,7 @@ export const HistoricalTests = function(props: TestProps) {
                   <Typography>
                     {showStatusText(test.status, darkMode)}{" "}
                     {showDateText(test.end_datetime, darkMode)}
-                    {showResolutionText(test.resolution, darkMode)}{" "}
+                    {showResolutionText(test.resolution, darkMode, false)}{" "}
                     {test.test_history_id === children.test_history_id ? ( // if it's current test - show the badge 
                       <Tooltip title="Current test">
                         <button

--- a/components/templates/TestResolution.tsx
+++ b/components/templates/TestResolution.tsx
@@ -5,8 +5,11 @@ import {
   Select,
   MenuItem,
   Typography,
+  IconButton,
+  Tooltip,
 } from "@material-ui/core"
-import { getResolutionName } from "./showResolution";
+import { getResolutionName } from "./showResolution"
+import DeleteIcon from '@material-ui/icons/Delete'
 
 interface TestProps {
   testHistoryId: any
@@ -71,7 +74,11 @@ export const TestResolution = function(props: TestProps) {
             <MenuItem value={6}>Environment issue</MenuItem>
         </Select>
       </FormControl> 
-    
+      <Tooltip title="Clear resolution for the current test">
+        <IconButton onClick={() => changeResolution("Not set")} style={{marginTop:"32px"}}>
+          <DeleteIcon></DeleteIcon>
+        </IconButton>
+      </Tooltip>
   </div>
   )
 }

--- a/components/templates/showResolution.js
+++ b/components/templates/showResolution.js
@@ -1,7 +1,8 @@
 import React from "react"
 import {Typography, Tooltip} from "@material-ui/core"
+import HistoryIcon from '@material-ui/icons/History'
 
-export function showResolutionText(resolution, darkMode) {
+export function showResolutionText(resolution, darkMode, historicalData) {
 
     if(resolution == 1) resolution =  "Not set"
     else if(resolution == 2) resolution =  "Test is flaky"
@@ -17,21 +18,54 @@ export function showResolutionText(resolution, darkMode) {
        
         if(darkMode) {
             resolutionBadge = (
-                <Tooltip title="Resolution">
-                    <button style={
-                        {
-                            color: "#dda057",
-                            margin: "5px",
-                            border: "1px #dda057 solid",
-                            backgroundColor: "#2a2a2a"
-                        }
-                    }>{resolution}</button>
-                </Tooltip>
+                <> 
+                    { !historicalData ? (
+                        <Tooltip title="Resolution for current test" >
+                            <button style={
+                                {
+                                    color: "#dda057",
+                                    margin: "5px",
+                                    border: "1px #dda057 solid",
+                                    backgroundColor: "#2a2a2a"
+                                }
+                            }> { resolution }
+                            </button>
+                        </Tooltip>
+                    ) : (
+                        <Tooltip title="Historical resolution inherited from previous tests">
+                        <button style={
+                            {
+                                color: "#dda057",
+                                margin: "5px",
+                                border: "1px #dda057 solid",
+                                backgroundColor: "#2a2a2a"
+                            }
+                        }>
+                            <HistoryIcon style={{color:"#dda057", fontSize: "small", marginTop:"3px", marginRight: "3px", marginBottom: "-2px"}}></HistoryIcon>
+                            <span>{ resolution }</span>
+                        </button>
+                    </Tooltip>
+                    )} 
+                </>
             )
         }
         else 
-            resolutionBadge = (
-                <Tooltip title="Resolution">
+        resolutionBadge = (
+            <> 
+                { !historicalData ? (
+                    <Tooltip title="Resolution for current test" >
+                        <button style={
+                            {
+                                color: "#dda057",
+                                margin: "5px",
+                                border: "1px #dda057 solid",
+                                backgroundColor: "white"
+                            }
+                        }> { resolution }
+                        </button>
+                    </Tooltip>
+                ) : (
+                    <Tooltip title="Historical resolution inherited from previous tests">
                     <button style={
                         {
                             color: "#dda057",
@@ -39,8 +73,13 @@ export function showResolutionText(resolution, darkMode) {
                             border: "1px #dda057 solid",
                             backgroundColor: "white"
                         }
-                    }>{resolution}</button>
+                    }>
+                        <HistoryIcon style={{color:"#dda057", fontSize: "small", marginTop:"3px", marginRight: "3px", marginBottom: "-2px"}}></HistoryIcon>
+                        <span>{ resolution }</span>
+                    </button>
                 </Tooltip>
+                )} 
+            </>
         )
     return resolutionBadge
     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,8 +72,9 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.light,
   },
   projectTitle: {
-    padding: "30px 0",
+    padding: "60px 0",
     textAlign: "center",
+    
   },
   pageTitleSectionDark: {
     backgroundColor: theme.palette.secondary.dark,
@@ -366,8 +367,15 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                       <ListItem
                         button
                       >  
-                        <Paper className={state.darkMode ? classes.paperDark : classes.paperLight} id={`paper_${project.project_id}`}>
-                          <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`}><SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon></Button> 
+                        <Paper 
+                          className={state.darkMode ? classes.paperDark : classes.paperLight} 
+                          id={`paper_${project.project_id}`} 
+                          onClick={() => Router.push(`/launches/${project.project_id}`)}
+                        >
+                          {/* TODO: need to rethink this approach with changing name */}
+                          <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`} disabled>
+                            <SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon>
+                          </Button> 
                           {/* modal to update project name */}
                           <Modal
                             open={openModal}
@@ -381,16 +389,14 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                                 <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
                               </form>
                             </div>
-                          </Modal> 
-                          <div onClick={() => Router.push(`/launches/${project.project_id}`)}>
+                          </Modal>
                             <Typography
-                              component="p"
                               variant="h4"
                               className={classes.projectTitle}
                             >
                               {project.name}
                             </Typography>
-                          </div>
+                       
                         </Paper>{" "}
                        
                       </ListItem>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -219,7 +219,7 @@ export interface SuiteAndTest {
               file_id: string
             }
           ]
-          is_flaky: string
+          is_flaky: boolean
         }
       ]
     }
@@ -253,7 +253,7 @@ export interface Test {
       file_id: string
     }
   ]
-  is_flaky: string
+  is_flaky: boolean
 }
 
 function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps>) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -391,6 +391,7 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                             </div>
                           </Modal>
                             <Typography
+                              component="p"
                               variant="h4"
                               className={classes.projectTitle}
                             >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.light,
   },
   projectTitle: {
-    padding: "60px 0",
+    padding: "30px 0",
     textAlign: "center",
     
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,7 +72,7 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.light,
   },
   projectTitle: {
-    paddingTop: theme.spacing(5),
+    padding: "30px 0",
     textAlign: "center",
   },
   pageTitleSectionDark: {
@@ -367,21 +367,20 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                         button
                       >  
                         <Paper className={state.darkMode ? classes.paperDark : classes.paperLight} id={`paper_${project.project_id}`}>
-                          <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`}><SettingsIcon style={{color: "grey", marginLeft:"90%"}}></SettingsIcon></Button> 
+                          <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`}><SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon></Button> 
                           {/* modal to update project name */}
                           <Modal
                             open={openModal}
                             onClose={handleModalClose}
                           >
                             <div style={modalStyle}  className={state.darkMode ? classes.modalDark : classes.modalLight}>
-                          <Typography style={{ marginBottom: "15px"}}> Update project name: 
-                          </Typography>
-                          <form noValidate autoComplete="off">
-                            <TextField id={`modal_${openModalProjectId}`} style={{width: "max-content"}} label={openModalProjectName} className={state.darkMode ? classes.rootSemiLight : classes.rootLight} variant="outlined"/>
-                            <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
-                          </form>
-
-                          </div>
+                              <Typography style={{ marginBottom: "15px"}}> Update project name: 
+                              </Typography>
+                              <form noValidate autoComplete="off">
+                                <TextField type="text" id={`modal_${openModalProjectId}`} style={{width: "max-content"}} label={openModalProjectName} className={state.darkMode ? classes.rootSemiLight : classes.rootLight} variant="outlined"/>
+                                <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
+                              </form>
+                            </div>
                           </Modal> 
                           <div onClick={() => Router.push(`/launches/${project.project_id}`)}>
                             <Typography

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -372,24 +372,24 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                           id={`paper_${project.project_id}`} 
                           onClick={() => Router.push(`/launches/${project.project_id}`)}
                         >
-                          {/* TODO: need to rethink this approach with changing name */}
-                          <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`} disabled>
-                            <SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon>
-                          </Button> 
-                          {/* modal to update project name */}
-                          <Modal
-                            open={openModal}
-                            onClose={handleModalClose}
-                          >
-                            <div style={modalStyle}  className={state.darkMode ? classes.modalDark : classes.modalLight}>
-                              <Typography style={{ marginBottom: "15px"}}> Update project name: 
-                              </Typography>
-                              <form noValidate autoComplete="off">
-                                <TextField type="text" id={`modal_${openModalProjectId}`} style={{width: "max-content"}} label={openModalProjectName} className={state.darkMode ? classes.rootSemiLight : classes.rootLight} variant="outlined"/>
-                                <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
-                              </form>
-                            </div>
-                          </Modal>
+                            {/* TODO: need to rethink this approach with changing name */}
+                            <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`} disabled>
+                              <SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon>
+                            </Button> 
+                            {/* modal to update project name */}
+                            <Modal
+                              open={openModal}
+                              onClose={handleModalClose}
+                            >
+                              <div style={modalStyle}  className={state.darkMode ? classes.modalDark : classes.modalLight}>
+                                <Typography style={{ marginBottom: "15px"}}> Update project name: 
+                                </Typography>
+                                <form noValidate autoComplete="off">
+                                  <TextField type="text" id={`modal_${openModalProjectId}`} style={{width: "max-content"}} label={openModalProjectName} className={state.darkMode ? classes.rootSemiLight : classes.rootLight} variant="outlined"/>
+                                  <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
+                                </form>
+                              </div>
+                            </Modal>
                             <Typography
                               component="p"
                               variant="h4"
@@ -397,9 +397,7 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                             >
                               {project.name}
                             </Typography>
-                       
                         </Paper>{" "}
-                       
                       </ListItem>
                     </List>
                   </Grid>

--- a/pages/launches/[launchesByProjectId].tsx
+++ b/pages/launches/[launchesByProjectId].tsx
@@ -55,13 +55,13 @@ const useStyles = makeStyles(theme => ({
     paddingBottom: theme.spacing(4),
   },
   paperLight: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(3),
     display: "flex",
     overflow: "auto",
     flexDirection: "column",
   },
   paperDark: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(3),
     display: "flex",
     overflow: "auto",
     flexDirection: "column",
@@ -244,7 +244,7 @@ function Launches({launches}: InferGetServerSidePropsType<typeof getServerSidePr
             <React.Fragment>
               <Tooltip title="Reload page">
               <Button color="secondary" size="small" onClick={handleReloadPage}>
-              <ReplayIcon fontSize="small" />
+              <ReplayIcon fontSize="small" color="primary"/>
               </Button>
               </Tooltip>
             </React.Fragment>
@@ -254,9 +254,9 @@ function Launches({launches}: InferGetServerSidePropsType<typeof getServerSidePr
         {/* Attempt to use notification as a component */}
         {/* {notification? EventNotification("There are new launches 🚀") : EventNotification("Connecting for events...") }  */}
         <Container maxWidth="lg" className={classes.container}>
-          <Grid container spacing={3} >
+          <Grid container spacing={4} >
             <Grid item xs={12} >
-              <Paper className={state.darkMode ? classes.paperDark : classes.paperLight}>
+              <Paper className={state.darkMode ? classes.paperDark : classes.paperLight} elevation={3}>
                 <Grid container>
                   <Grid item xs={10}>
                     <Typography
@@ -290,7 +290,7 @@ function Launches({launches}: InferGetServerSidePropsType<typeof getServerSidePr
                   </Grid>
                 </Grid>
                 {launches[0] ? ( // checking if props exist
-                  <div>
+                  <div style={{paddingTop:"15px"}}>
                     <Table size="small" >
                       <TableHead>
                         <TableRow>

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -257,7 +257,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                     <div
                       style={{
                         display: "flex",
-                        paddingLeft: "195px",
+                        paddingLeft: "145px",
                         alignItems: "baseline",
                       }}
                     >

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -245,7 +245,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                         <Button
                           href={
                             tests[0].test_run_data
-                              .spectre_test_run_url
+                              .spectre_test_run_url + "?status=fail"
                           }
                           className={classes.spectreButton}
                         >

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles(theme => ({
     paddingBottom: theme.spacing(4),
   },
   paperDark: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(3),
     display: "flex",
     overflow: "auto",
     flexDirection: "column",
@@ -48,7 +48,7 @@ const useStyles = makeStyles(theme => ({
     border: "1px grey solid",
   },
   paperLight: {
-    padding: theme.spacing(2),
+    padding: theme.spacing(3),
     display: "flex",
     overflow: "auto",
     flexDirection: "column",
@@ -213,9 +213,9 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
             </div>
           </div>
           <Container maxWidth="lg" className={classes.container}>
-            <Grid container spacing={3}>
+            <Grid container spacing={4}>
               <Grid item xs={12}>
-              <Paper className={state.darkMode ? classes.paperDark : classes.paperLight}>
+              <Paper className={state.darkMode ? classes.paperDark : classes.paperLight} elevation={2}>
                   <Typography
                     variant="h6"
                     style={{ fontWeight: 400, margin: "5px" }}
@@ -235,7 +235,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                   <div
                     style={{
                       display: "flex",
-                      marginTop: "20px",
+                      marginTop: "30px",
                       alignItems: "baseline",
                     }}
                   >
@@ -256,7 +256,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                     <div
                       style={{
                         display: "flex",
-                        paddingLeft: "100px",
+                        paddingLeft: "195px",
                         alignItems: "baseline",
                       }}
                     >

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -248,6 +248,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                               .spectre_test_run_url + "?status=fail"
                           }
                           className={classes.spectreButton}
+                          target="_blank"
                         >
                           Spectre
                         </Button>


### PR DESCRIPTION
- Adding paddings here and there
- Spectre button: opening spectre in the new tab with only failing screenshots
- fixing is_flaky thing
- adding delete button for resolution
- adding historical icon for resolution
- if you click on the screenshot - open in the new tab
- disabling project settings for now
<img width="448" alt="Screenshot 2020-10-06 at 18 14 52" src="https://user-images.githubusercontent.com/44492659/95239460-ec290480-0802-11eb-898e-d790aacb6106.png">
<img width="415" alt="Screenshot 2020-10-06 at 18 16 03" src="https://user-images.githubusercontent.com/44492659/95239462-ecc19b00-0802-11eb-9c32-8e87e6c9ddb5.png">
