### PR TITLE
UI improvements - style notes, badge for slow tests, suite checkbox

### DIFF
--- a/components/templates/ListOfSuites.tsx
+++ b/components/templates/ListOfSuites.tsx
@@ -12,9 +12,12 @@ import {
   AccordionDetails,
   AccordionSummary,
   List,
+  Tooltip,
+  FormControlLabel,
 } from "@material-ui/core"
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore"
 import { SuiteAndTest } from "../../pages"
+import UseAnimations from "react-useanimations"
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -74,6 +77,9 @@ const useStyles = makeStyles(theme => ({
   },
   testBackgroundDark: {
     backgroundColor: theme.palette.secondary.main,
+  },
+  greyTick: {
+    color: "#d4d3d3"
   },
 }))
 
@@ -151,6 +157,17 @@ export const ListOfSuites = function(props: Props) {
                     suite.tests_skipped,
                     statsArray
                   )}
+                  <FormControlLabel
+            aria-label="Reviewed"
+            onClick={(event) => event.stopPropagation()} // to stop accordion from expanding
+            onFocus={(event) => event.stopPropagation()}
+            control={
+              <Tooltip title="Mark suite as reviewed"> 
+                <UseAnimations animationKey="checkbox"  style={{position: "absolute", right:"55px", width:"20px" }} className={classes.greyTick} />
+              </Tooltip>
+            } 
+            label=""
+          />
                 </AccordionSummary>
                 <AccordionDetails>
                   {/* Expandable tests list for each suite */}

--- a/components/templates/Notes.tsx
+++ b/components/templates/Notes.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Button, FormControl, List, makeStyles, TextField } from '@material-ui/core';
+import { Button, FormControl, makeStyles, TextField, Paper } from '@material-ui/core';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
   addNoteButton: {
-      backgroundColor: theme.palette.primary.main,
       width: "90px",
       height: "30px",
-      marginTop: "5px",
       border: "1px #a7bab1 solid",
       fontSize: "12px",
   }
@@ -80,26 +78,28 @@ export const Notes = function(props: NotesProps) {
 
     return (
       <>
-      <FormControl style={{display: "flex"}}>
-          <TextField id="noteText" type="text" placeholder="Enter a new note" multiline autoFocus required/>
-          <TextField id="noteAddedBy"  type="text" placeholder="Enter your name"/>
-      </FormControl>
-      <Button id="submit" onClick={() => submit()} className={classes.addNoteButton}>Add note</Button>
-      <List style={{maxHeight: 200, overflow: 'auto'}}>
-        {loading || noData ?
-          <p>There are no notes for this test. Feel free to add one :) </p>
-            : (
-            notes.reverse().map(note => (
-              <>
-              <div>{note.note_text}</div>
-              <div style={{display: 'flex', color: 'grey'}}>
-                <div style={{paddingRight: '5px'}}>{note.added_by}</div>
-                <div>{note.created_datetime}</div>
-              </div>
-              </>
-              ))
-          )} 
-          </List>
+        <div style={{overflow:"auto", paddingTop: "23px", paddingLeft:"40px", maxHeight: 430, marginLeft:"-40px"}}>
+          <FormControl style={{display: "block"}}>
+            <Paper elevation={3} style={{color:"#000", background:"#ffc", display:"block", height: "12em",  marginLeft:"1em", marginTop: "5px", float:"left", width:"12em", padding: "5px", marginBottom:"2px"}} square={true}>
+              <TextField id="noteText" type="text" placeholder="New note" autoFocus style={{justifyContent:"center", alignItems:"center", display:"flex", padding: "5px"}}/>
+              <TextField id="noteAddedBy"  type="text" placeholder="Your name" style={{justifyContent:"center", alignItems:"center", display:"flex", padding: "15px 5px 15px 5px"}}/>
+              <Button id="submit" onClick={() => submit()} className={classes.addNoteButton} style={{margin:"10px 30px 10px"}}>Add note</Button>
+            </Paper>
+          </FormControl>
+          {loading || noData ?
+            <p style={{paddingTop: "30px", paddingLeft:"240px"}}>There are no notes for this test. Feel free to add one :) </p>
+                : (
+                    notes.reverse().map(note => (
+                      <Paper elevation={3} style={{color:"#000", background:"#ffc", display:"block", height: "12em",  marginLeft:"1em", marginTop: "5px", float:"left", width:"12em", padding: "5px"}} square={true}>
+                        <p style={{fontFamily:"Kalam", fontStyle:"italic", fontSize:"1.25em", justifyContent:"center", alignItems:"center", display:"flex", wordBreak:"break-word"}}>{note.note_text}</p>
+                        <p style={{ fontStyle:"italic",  fontSize:"0.9em", color:"#8b8888"}}>{note.added_by}</p>
+                        <p style={{ fontStyle:"italic",  fontSize:"0.8em", color:"#8b8888"}}>{note.created_datetime.substring(0, note.created_datetime.length - 7)}</p>
+                      </Paper>
+                      ))
+                
+                  )
+          } 
+        </div>
       </>
     )
 }

--- a/components/templates/Test.tsx
+++ b/components/templates/Test.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { makeStyles } from "@material-ui/core/styles"
-import { Paper, Typography } from "@material-ui/core"
+import { Paper, Typography, Tooltip } from "@material-ui/core"
 import {
   TestErrorMessageAccordion,
   TestMediaAccordion,
 } from "./TestExpandablePanels"
 import { TestResolution } from "./TestResolution"
-import { showStatusText, HistoricalTests, showIsFlakyBadge } from "."
+import { showStatusText, HistoricalTests, showIsFlakyBadgeTestExpanded } from "."
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs"
 import "react-tabs/style/react-tabs.css"
 import { Notes } from "./Notes"
@@ -70,6 +70,16 @@ export const TestExpanded = function(props: TestProps) {
     else return "black"
   }
 
+  function setSlowTestBadge(duration) {
+    // if longer than 1 min
+    if (duration > "1") 
+      return (
+        <Tooltip title="This test took longer than 1 min to execute">
+            <span style={{ border:"1px solid #d62727", padding: "2px 5px 2px 5px", color:"#d62727", marginLeft:"13px"}}>Potentially slow test</span>
+        </Tooltip>
+      )
+  }
+
   return (
     <div
       key={children.test_history_id}
@@ -84,12 +94,12 @@ export const TestExpanded = function(props: TestProps) {
               fontWeight: 580,
               fontSize: "18px",
               marginTop: "20px",
-              wordBreak: "break-all",
+              wordBreak: "break-word",
               whiteSpace: "pre-wrap",
             }}
             className={darkMode ? classes.textColorDarkMode : classes.textColorLightMode}
           >
-            {showIsFlakyBadge(children.status, children.is_flaky)} 
+            {showIsFlakyBadgeTestExpanded(children.status, children.is_flaky)} 
             {showStatusText(children.status, darkMode)} 
            <span style={{paddingLeft:"8px"}}> {children.name}</span>
           </Typography>
@@ -121,6 +131,7 @@ export const TestExpanded = function(props: TestProps) {
                   {children.duration.seconds}.
                   {convertToSeconds(children.duration.microseconds)}s{" "}
                 </span>
+                {setSlowTestBadge(children.duration.minutes)} 
               </Typography>
               {children.retries ? ( // if there is any retries - show
                 <Typography style={{ paddingTop: "20px" }}>
@@ -131,17 +142,7 @@ export const TestExpanded = function(props: TestProps) {
                 <div></div>
               )}
               {children.message ? ( // if there is any error message - show the info, else - test passed
-                <div>
-                  <Typography
-                    style={{ paddingTop: "20px", paddingBottom: "20px" }}
-                  >
-                    Error type:
-                    <span style={{ color: "grey" }}>
-                      {" "}
-                      {children.error_type}{" "}
-                    </span>
-                  </Typography>
-
+                <div style={{ paddingTop: "10px" }}>
                   <TestErrorMessageAccordion>
                     {children}
                   </TestErrorMessageAccordion>

--- a/components/templates/showStatusIcon.js
+++ b/components/templates/showStatusIcon.js
@@ -17,7 +17,7 @@ export function showStatusIcon(status, isFlaky = false) {
   } else if (status === "Failed" || status === "Incomplete") {
     statusIcon = (
       <Tooltip title="Failed">
-        <CloseIcon style={{ color: "red" }}></CloseIcon>
+        <CloseIcon style={{ color: "#d62727" }}></CloseIcon>
       </Tooltip>
     )
   } else if (status === "Skipped") {
@@ -37,7 +37,7 @@ export function showStatusIcon(status, isFlaky = false) {
   }
 
   if (isFlaky && (status === "Passed" || status === "Failed")) {
-    statusIcon = showIsFlakyBadge(status, isFlaky)
+    statusIcon = showIsFlakyBadgeList(status, isFlaky)
   }
   return statusIcon
 }
@@ -78,12 +78,12 @@ export function showStatusText(status, darkMode) {
       statusIcon = (
         <button
           style={{
-            color: "red",
+            color: "#d62727",
             margin: "5px",
-            border: "1px red solid",
+            border: "1px #d62727 solid",
             backgroundColor: "#2a2a2a",
             fontSize: "13px",
-            paddingRight: "14px",
+            paddingRight: "6px",
           }}
         >
           FAILED
@@ -93,12 +93,12 @@ export function showStatusText(status, darkMode) {
       statusIcon = (
         <button
           style={{
-            color: "red",
+            color: "#d62727",
             margin: "5px",
-            border: "1px red solid",
+            border: "1px #d62727 solid",
             backgroundColor: "white",
             fontSize: "13px",
-            paddingRight: "14px",
+            paddingRight: "6px",
           }}
         >
           FAILED
@@ -170,13 +170,33 @@ export function showStatusText(status, darkMode) {
 }
 
 
-export function showIsFlakyBadge(status, isFlaky) {
+export function showIsFlakyBadgeList(status, isFlaky) {
   let statusIcon
 
   if (isFlaky && status === "Failed") {
     statusIcon = (
       <Tooltip title="Test failed. Might be flaky. Failing more than 5/10 times">
-        <WarningIcon style={{color: "red", width:"30px", height:"25px", marginBottom:"-7px"}}></WarningIcon>  
+        <WarningIcon style={{color: "#d62727", width:"30px", height:"25px", marginBottom:"3px", marginLeft:"-3px"}}></WarningIcon>  
+      </Tooltip>
+    )
+  }
+  if (isFlaky && status === "Passed") {
+    statusIcon = (
+      <Tooltip title="Test passed this time. But might be flaky, was failing in past">
+        <WarningIcon style={{color: "green", width:"30px", height:"25px", marginBottom:"3px", marginLeft:"-3px"}}></WarningIcon>  
+      </Tooltip>
+    )
+  }
+  return statusIcon
+}
+
+export function showIsFlakyBadgeTestExpanded(status, isFlaky) {
+  let statusIcon
+
+  if (isFlaky && status === "Failed") {
+    statusIcon = (
+      <Tooltip title="Test failed. Might be flaky. Failing more than 5/10 times">
+        <WarningIcon style={{color: "#d62727", width:"30px", height:"25px", marginBottom:"-7px"}}></WarningIcon>  
       </Tooltip>
     )
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,9 +7,6 @@ import {
   List,
   NoSsr,
   Switch,
-  Button,
-  TextField,
-  Modal,
 } from "@material-ui/core"
 import { GetServerSideProps } from 'next'
 import { InferGetServerSidePropsType } from 'next'
@@ -19,7 +16,6 @@ import { BasePage } from "../components/templates"
 import fetch from "isomorphic-unfetch"
 import useSocket from '../hooks/useSocket'
 import Router from "next/router"
-import SettingsIcon from '@material-ui/icons/Settings'
 import WbSunnyIcon from '@material-ui/icons/WbSunny'
 import Brightness2Icon from '@material-ui/icons/Brightness2'
 
@@ -72,7 +68,7 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.secondary.light,
   },
   projectTitle: {
-    padding: "30px 0",
+    padding: "60px 0",
     textAlign: "center",
     
   },
@@ -341,51 +337,6 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
   const handleDarkModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setState({ ...state, [event.target.name]: event.target.checked });
   };
-  
-  function getModalStyle() {
-    return {
-      top: `50%`,
-      left: `50%`,
-      transform: `translate(-50%, -50%)`,
-    }
-  }
-  const [openModal, setOpenModal] = React.useState(false);
-  const [modalStyle] = React.useState(getModalStyle);
-  const [openModalProjectId, setOOpenModalProjectId] = React.useState("");
-  const [openModalProjectName, setOpenModalProjectName] = React.useState("");
-
-  const handleModalOpen = (id, name) => {
-    setOOpenModalProjectId(id)
-    setOpenModalProjectName(name)
-    setOpenModal(true);
-  }
-
-  const handleModalClose = () => {
-    setOpenModal(false);
-  }
-
-  async function getNewProjectName(projectId) {
-    const projectName = (document.getElementById("modal_" + projectId) as HTMLInputElement).value
-    
-    const requestOptions = {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        id: projectId,
-        name: projectName
-      }),
-    }
-    console.log(requestOptions)
-
-    const response = await fetch(
-      `${process.env.publicDeltaCore}/api/v1/update_project_name`,
-      requestOptions
-    )
-    await response.json()
-    if (typeof window !== 'undefined') {
-      window.location.reload(false) // reloading the page whe project name is changed
-      }
-  }
 
   return (
       <NoSsr>
@@ -425,24 +376,7 @@ function Index({projects}: InferGetServerSidePropsType<typeof getServerSideProps
                           id={`paper_${project.project_id}`} 
                           onClick={() => Router.push(`/launches/${project.project_id}`)}
                         >
-                            {/* TODO: need to rethink this approach with changing name */}
-                            <Button  onClick={() => handleModalOpen(project.project_id, project.name) } id={`${project.project_id}`} disabled>
-                              <SettingsIcon style={{color: "#c7c5c5", marginLeft:"90%", width:"23px"}}></SettingsIcon>
-                            </Button> 
-                            {/* modal to update project name */}
-                            <Modal
-                              open={openModal}
-                              onClose={handleModalClose}
-                            >
-                              <div style={modalStyle}  className={state.darkMode ? classes.modalDark : classes.modalLight}>
-                                <Typography style={{ marginBottom: "15px"}}> Update project name: 
-                                </Typography>
-                                <form noValidate autoComplete="off">
-                                  <TextField type="text" id={`modal_${openModalProjectId}`} style={{width: "max-content"}} label={openModalProjectName} className={state.darkMode ? classes.rootSemiLight : classes.rootLight} variant="outlined"/>
-                                  <Button variant="contained" style={{border: "1px solid grey", marginTop: "15px", marginLeft: "30px"}} onClick={() => getNewProjectName(project.project_id)}>Submit</Button> 
-                                </form>
-                              </div>
-                            </Modal>
+
                             <Typography
                               component="p"
                               variant="h4"

--- a/pages/tests/[testsByRunId].tsx
+++ b/pages/tests/[testsByRunId].tsx
@@ -388,7 +388,7 @@ function Tests({tests}: InferGetServerSidePropsType<typeof getServerSideProps>) 
                         style={{
                           fontStyle: "italic",
                           margin: "20px",
-                          color: "red",
+                          color: "#d62727",
                         }}
                       >
                         Sorry, there are no matching tests for this filter


### PR DESCRIPTION
- Styling notes section to look more like notes (not perfect yet, but looks better, I think )
<img width="411" alt="Screenshot 2020-11-05 at 12 27 39" src="https://user-images.githubusercontent.com/44492659/98241074-4e8c3680-1f62-11eb-8ecc-8a3d0009ff51.png">


- Adding a badge for slow tests
<img width="338" alt="Screenshot 2020-11-05 at 13 57 35" src="https://user-images.githubusercontent.com/44492659/98250038-e1cb6900-1f6e-11eb-9034-c589ab8e8574.png">

- Adding a small checkbox next to each suite to mark it as reviewed 
<img width="586" alt="Screenshot 2020-11-05 at 12 26 54" src="https://user-images.githubusercontent.com/44492659/98250092-f14ab200-1f6e-11eb-9ed5-48afd9a357fa.png">


