### PR TITLE
Tiny improvement to colour palette

### DIFF
--- a/components/templates/Notes.tsx
+++ b/components/templates/Notes.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Button, FormControl, makeStyles, TextField, Paper } from '@material-ui/core';
+import { Button, FormControl, makeStyles, Paper, TextareaAutosize } from '@material-ui/core';
 
 const useStyles = makeStyles(() => ({
   addNoteButton: {
@@ -81,8 +81,8 @@ export const Notes = function(props: NotesProps) {
         <div style={{overflow:"auto", paddingTop: "23px", paddingLeft:"40px", maxHeight: 430, marginLeft:"-40px"}}>
           <FormControl style={{display: "block"}}>
             <Paper elevation={3} style={{color:"#000", background:"#ffc", display:"block", height: "12em",  marginLeft:"1em", marginTop: "5px", float:"left", width:"12em", padding: "5px", marginBottom:"2px"}} square={true}>
-              <TextField id="noteText" type="text" placeholder="New note" autoFocus style={{justifyContent:"center", alignItems:"center", display:"flex", padding: "5px"}}/>
-              <TextField id="noteAddedBy"  type="text" placeholder="Your name" style={{justifyContent:"center", alignItems:"center", display:"flex", padding: "15px 5px 15px 5px"}}/>
+              <TextareaAutosize id="noteText" placeholder="Note" style={{justifyContent:"center", alignItems:"center", display:"flex", paddingBottom: "65px", paddingTop: "15px", marginTop: "8px", marginLeft: "8px", width: "90%", backgroundColor:"#ffc", borderColor:"#ffc"}} />
+              {/* <TextField id="noteAddedBy"  type="text" placeholder="Author" autoFocus style={{justifyContent:"center", alignItems:"center", display:"flex", paddingTop: "5px", paddingLeft:"7px", width:"97%"}}/> */}
               <Button id="submit" onClick={() => submit()} className={classes.addNoteButton} style={{margin:"10px 30px 10px"}}>Add note</Button>
             </Paper>
           </FormControl>

--- a/components/templates/Test.tsx
+++ b/components/templates/Test.tsx
@@ -128,10 +128,14 @@ export const TestExpanded = function(props: TestProps) {
             <TabPanel>
             <SmartLinksTest project_id={project_id} environment={environment} test_id={children.test_id}/>
             {showIsFlakyBadgeTestExpanded(children.status, children.is_flaky)} 
+            {children.duration ? (
               <Typography style={{ paddingTop: "20px" }}>
                 Full path:
                 <span style={{ color: "grey" }}> {children.file}</span>
               </Typography>
+            ) : (
+              <></>
+            )}
               {children.duration ? (
               <Typography style={{ paddingTop: "20px" }}>
                 Duration:

--- a/components/templates/settings/SmartLinkOptions.tsx
+++ b/components/templates/settings/SmartLinkOptions.tsx
@@ -62,8 +62,8 @@ export default function SmartLinkOptions(children: any) {
     setLocation(event.target.value as number);
   };
 
-  const colorSet1 = ["#f2c0b3", "#eacba9" ,"#d2d86f", "#b7eea6", "#88d86f"]
-  const colorSet2 = ["#94CAF7", "#b7b6f6", "#dbbeff", "#f0b8f6", "#f2bbbb"]
+  const colorSet1 = ["#eacba9", "#ecf6b6", "#d2d86f", "#b7eea6", "#88d86f"]
+  const colorSet2 = ["#94CAF7", "#b7b6f6", "#dbbeff", "#f0b8f6", "#f6bdb6"]
 
   async function createSmartLink() {
 

--- a/components/templates/settings/SmartLinkOptions.tsx
+++ b/components/templates/settings/SmartLinkOptions.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   Checkbox,
 } from "@material-ui/core"
-import { CirclePicker } from "react-color"
 import React from "react"
 import SmartLinks from "./SmartLinks"
 import HelpIcon from '@material-ui/icons/Help'
@@ -34,11 +33,14 @@ const useStyles = makeStyles((theme: Theme) =>
       position: "relative",
       left: "80%",
     },
-    textDark:{
+    textDark: {
       color: theme.palette.secondary.light
     },
     textLight:{
       color: "black"
+    },
+    colorButton: {      
+      margin: "5px",
     },
   })
 )
@@ -46,18 +48,23 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function SmartLinkOptions(children: any) {
   const { project_id, darkMode } = children
   const classes = useStyles()
-  const [color, setColor] = React.useState("#90caf9")
+  const [color, setColor] = React.useState("#d8846f")
   const [filtered, setFiltered] = React.useState(false)
   const [location, setLocation] = React.useState(1)
 
-  const handleChangeComplete = clr => {
-    setColor(clr.hex)
+  const handleColourPicking = (hex) => {
+    document.getElementById(color).style.color = color
+    setColor(hex)
+    document.getElementById(hex).style.color = 'black'
   }
 
   const handleLinkLocationChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setLocation(event.target.value as number);
   };
-  
+
+  const colorSet1 = ["#d8846f", "#d8a66f" ,"#d2d86f", "#88d86f", "#6fd8a0"]
+  const colorSet2 = ["#81bdf0", "#6fa0d8", "#886fd8", "#cd6fd8", "#d86f7a"]
+
   async function createSmartLink() {
 
     const data = {
@@ -189,8 +196,15 @@ export default function SmartLinkOptions(children: any) {
         <Typography>
        6. Choose the color for the button (optional):
       </Typography>
-      <div  style={{ paddingTop: "20px", paddingLeft:"10%"}}>
-      <CirclePicker color={color} onChangeComplete={handleChangeComplete} />
+      <div  style={{ paddingTop: "20px"}}>
+      {colorSet1.map(color =>
+      <Button id ={color} className={classes.colorButton} style={{backgroundColor: color, color: color}} onClick={() => handleColourPicking(color)}>✓</Button>
+      )}
+      </div>
+      <div  style={{paddingBottom: "30px"}}>
+      {colorSet2.map(color =>
+      <Button id ={color} className={classes.colorButton} style={{backgroundColor: color, color: color}} onClick={() => handleColourPicking(color)}>✓</Button>
+      )}
       </div>
       <Button
         variant="contained"

--- a/components/templates/settings/SmartLinkOptions.tsx
+++ b/components/templates/settings/SmartLinkOptions.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function SmartLinkOptions(children: any) {
   const { project_id, darkMode } = children
   const classes = useStyles()
-  const [color, setColor] = React.useState("#d8846f")
+  const [color, setColor] = React.useState("#f2c0b3")
   const [filtered, setFiltered] = React.useState(false)
   const [location, setLocation] = React.useState(1)
 
@@ -62,8 +62,8 @@ export default function SmartLinkOptions(children: any) {
     setLocation(event.target.value as number);
   };
 
-  const colorSet1 = ["#d8846f", "#d8a66f" ,"#d2d86f", "#88d86f", "#6fd8a0"]
-  const colorSet2 = ["#81bdf0", "#6fa0d8", "#886fd8", "#cd6fd8", "#d86f7a"]
+  const colorSet1 = ["#f2c0b3", "#eacba9" ,"#d2d86f", "#b7eea6", "#88d86f"]
+  const colorSet2 = ["#94CAF7", "#b7b6f6", "#dbbeff", "#f0b8f6", "#f2bbbb"]
 
   async function createSmartLink() {
 

--- a/components/templates/settings/SmartLinkOptions.tsx
+++ b/components/templates/settings/SmartLinkOptions.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function SmartLinkOptions(children: any) {
   const { project_id, darkMode } = children
   const classes = useStyles()
-  const [color, setColor] = React.useState("#f2c0b3")
+  const [color, setColor] = React.useState("#eacba9")
   const [filtered, setFiltered] = React.useState(false)
   const [location, setLocation] = React.useState(1)
 
@@ -216,9 +216,10 @@ export default function SmartLinkOptions(children: any) {
         Save
       </Button>
       </div>
+      {/* Existing links list */}
       <Grid container spacing={1}>
         <Grid item xs={12} md={12}>
-          <SmartLinks project_id={project_id} darkMode={darkMode}/>
+          <SmartLinks project_id={project_id} darkMode={darkMode} id="existing_smart_links"/>
         </Grid>
       </Grid>
     </div>

--- a/components/templates/settings/SmartLinks.tsx
+++ b/components/templates/settings/SmartLinks.tsx
@@ -11,10 +11,11 @@ import {
   makeStyles,
   Theme,
   Divider,
+  Tooltip,
 } from "@material-ui/core"
 import DeleteIcon from "@material-ui/icons/Delete"
 import LabelImportantIcon from "@material-ui/icons/LabelImportant"
-import EditIcon from "@material-ui/icons/Edit"
+import FileCopyIcon from '@material-ui/icons/FileCopy'
 import React from "react"
 import getSmartLinks from "../../../data/SmartLinks"
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward'
@@ -85,20 +86,27 @@ export default function SmartLinks(children: any) {
                       </Avatar>
                     </ListItemAvatar>
                     <ListItemText
+                    className={darkMode ? classes.dark : classes.light}
                       primary={
                           smart_link.environment
                           ? smart_link.label + " - " + smart_link.environment.substring(0, 25)
                           : smart_link.label
-                      }
+                      } 
                       secondary={
                         smart_link.smart_link.substring(0, 40)
                       }
                     />
                     <ListItemSecondaryAction>
-                      <IconButton edge="end" aria-label="edit" className={darkMode ? classes.dark : classes.light}>
-                        <EditIcon />
-                      </IconButton>
-                      <IconButton
+                    <IconButton
+                        edge="end"
+                        onClick={() => navigator.clipboard.writeText(smart_link.smart_link) }
+                        className={darkMode ? classes.dark : classes.light}
+                    >  
+                      <Tooltip title="Copy the link to clipboard"> 
+                        <FileCopyIcon />
+                      </Tooltip>
+                    </IconButton>
+                    <IconButton
                         edge="end"
                         aria-label="delete"
                         onClick={() =>


### PR DESCRIPTION
* changing colour palette for smart links
<img width="278" alt="Screenshot 2020-12-21 at 11 03 28" src="https://user-images.githubusercontent.com/44492659/102770516-3179be80-437c-11eb-848f-45a1150c273b.png">
* adding Copy button, so that we can copy the full link, in case we need to re-upload,etc.
<img width="549" alt="Screenshot 2020-12-21 at 14 19 42" src="https://user-images.githubusercontent.com/44492659/102786637-c1793180-4397-11eb-8fe6-3e2769eced59.png">
